### PR TITLE
chore: start extension and format json5

### DIFF
--- a/client/tools/formatter.ts
+++ b/client/tools/formatter.ts
@@ -269,6 +269,7 @@ export default class FormatterTool implements ToolInterface {
       "handlebars",
       "json",
       "jsonc",
+      "json5",
       "less",
       "markdown",
       "html",

--- a/package.json
+++ b/package.json
@@ -314,6 +314,7 @@
     "onLanguage:javascript",
     "onLanguage:javascriptreact",
     "onLanguage:json",
+    "onLanguage:json5",
     "onLanguage:jsonc",
     "onLanguage:less",
     "onLanguage:markdown",


### PR DESCRIPTION
Oriented what other VS Code plugins defining as json5:
- https://github.com/BlueGlassBlock/better-json5/blob/master/package.json#
- https://github.com/mrmlnc/vscode-json5/blob/master/package.json

Now VS Code sends the language id "json5" to the server, which `oxfmt` can then correctly format 🤞 

```

2026-02-14 15:01:15.950 [info] [Trace - 3:01:15 PM] Sending notification 'textDocument/didOpen'.
2026-02-14 15:01:15.950 [info] Params: {
    "textDocument": {
        "uri": "file:///home/sysix/dev/oxc-vscode/test.json5",
        "languageId": "json5",
        "version": 1,
        "text": "{\n  hello: \"hello\",\n}\n"
    }
}

```
