### PR TITLE
fix: support formatting language id without `scheme`

### DIFF
--- a/client/tools/formatter.ts
+++ b/client/tools/formatter.ts
@@ -299,7 +299,6 @@ export default class FormatterTool implements ToolInterface {
         })),
         ...supportedLanguageIds.map((language) => ({
           language,
-          scheme: "untitled",
         })),
       ],
       initializationOptions: configService.formatterServerConfig,


### PR DESCRIPTION
The editor said that the extension does not support typescript files. 
The selector filtering from VSCode is too strict for us. Use always the language-id, it should not matter for the `oxfmt` lsp server