### PR TITLE
chore: migrate oxlint CLI type flags to config options

### DIFF
--- a/tests/integration/commands.spec.ts
+++ b/tests/integration/commands.spec.ts
@@ -6,7 +6,6 @@ import {
   deleteFixtures,
   sleep,
   testSingleFolderMode,
-  waitForCommand,
   WORKSPACE_DIR,
 } from "../test-helpers";
 
@@ -17,22 +16,16 @@ suiteSetup(async () => {
 });
 
 teardown(async () => {
-  await workspace.getConfiguration("oxc").update("enable.oxlint", true);
-  await workspace.getConfiguration("oxc").update("enable.oxfmt", true);
   const edit = new WorkspaceEdit();
   edit.deleteFile(fileUri, {
     ignoreIfNotExists: true,
   });
   await workspace.applyEdit(edit);
-  await workspace.saveAll();
   await deleteFixtures();
 });
 
 suite("commands", () => {
   testSingleFolderMode("listed commands", async () => {
-    if (process.env.SKIP_LINTER_TEST !== "true") {
-      await waitForCommand("oxc.fixAll");
-    }
     const oxcCommands = (await commands.getCommands(true)).filter((x) => x.startsWith("oxc."));
 
     const expectedCommands = ["oxc.showOutputChannel", "oxc.showOutputChannelFormatter"];
@@ -82,10 +75,6 @@ suite("commands", () => {
     if (process.env.SKIP_LINTER_TEST === "true") {
       return;
     }
-    await workspace.getConfiguration("oxc").update("enable.oxlint", true);
-    await workspace.saveAll();
-    await waitForCommand("oxc.fixAll");
-
     const service = new ConfigService();
     strictEqual(service.vsCodeConfig.enableOxlint, true);
 
@@ -104,9 +93,6 @@ suite("commands", () => {
     if (process.env.SKIP_FORMATTER_TEST === "true") {
       return;
     }
-    await workspace.getConfiguration("oxc").update("enable.oxfmt", true);
-    await workspace.saveAll();
-
     const service = new ConfigService();
     strictEqual(service.vsCodeConfig.enableOxfmt, true);
 
@@ -126,10 +112,6 @@ suite("commands", () => {
     if (process.env.SKIP_LINTER_TEST === "true") {
       return;
     }
-    await workspace.getConfiguration("oxc").update("enable.oxlint", true);
-    await workspace.saveAll();
-    await waitForCommand("oxc.fixAll");
-
     const edit = new WorkspaceEdit();
     edit.createFile(fileUri, {
       contents: Buffer.from("/* 😊 */debugger;"),

--- a/tests/integration/e2e_server_linter.spec.ts
+++ b/tests/integration/e2e_server_linter.spec.ts
@@ -21,7 +21,6 @@ import {
   sleep,
   testMultiFolderMode,
   testSingleFolderMode,
-  waitFor,
   waitForDiagnosticChange,
   WORKSPACE_DIR,
   WORKSPACE_SECOND_DIR,
@@ -39,8 +38,6 @@ teardown(async () => {
   await workspace.getConfiguration("oxc").update("fixKind", undefined);
   await workspace.getConfiguration("oxc").update("tsConfigPath", undefined);
   await workspace.getConfiguration("oxc").update("typeAware", undefined);
-  await workspace.getConfiguration("oxc").update("enable.oxlint", true);
-  await workspace.getConfiguration("oxc").update("enable.oxfmt", true);
   await workspace.getConfiguration("oxc").update("fmt.experimental", undefined);
   await workspace.getConfiguration("oxc").update("fmt.configPath", undefined);
   await workspace.getConfiguration("editor").update("defaultFormatter", undefined);
@@ -338,23 +335,14 @@ suite("E2E Server Linter", () => {
 
     await workspace.getConfiguration("oxc").update("enable.oxlint", false);
     await workspace.saveAll();
-    try {
-      await waitFor(
-        async () => {
-          const diagnostics = await getDiagnostics("debugger.js");
-          return diagnostics.length === 0;
-        },
-        15_000,
-        250,
-      );
+    await waitForDiagnosticChange();
 
-      const secondDiagnostics = await getDiagnostics("debugger.js");
-      strictEqual(secondDiagnostics.length, 0);
-    } finally {
-      // enable it for other tests even if assertions fail
-      await workspace.getConfiguration("oxc").update("enable.oxlint", true);
-      await workspace.saveAll();
-      await sleep(500);
-    }
+    const secondDiagnostics = await getDiagnostics("debugger.js");
+    strictEqual(secondDiagnostics.length, 0);
+
+    // enable it for other tests
+    await workspace.getConfiguration("oxc").update("enable.oxlint", true);
+    await workspace.saveAll();
+    await sleep(500);
   });
 });

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -168,25 +168,3 @@ export async function waitForDiagnosticChange(): Promise<void> {
     }),
   );
 }
-
-export async function waitFor(
-  condition: () => boolean | Promise<boolean>,
-  timeoutMs = 10_000,
-  pollIntervalMs = 100,
-): Promise<void> {
-  const timeoutAt = Date.now() + timeoutMs;
-  do {
-    // oxlint-disable-next-line eslint/no-await-in-loop -- polling loop
-    if (await condition()) {
-      return;
-    }
-    // oxlint-disable-next-line eslint/no-await-in-loop -- polling loop
-    await sleep(pollIntervalMs);
-  } while (Date.now() < timeoutAt);
-
-  throw new Error(`Timed out waiting for condition after ${timeoutMs}ms`);
-}
-
-export async function waitForCommand(command: string, timeoutMs = 10_000): Promise<void> {
-  await waitFor(async () => (await commands.getCommands(true)).includes(command), timeoutMs);
-}


### PR DESCRIPTION
## Summary
- upgrade oxlint to latest
- migrate `--type-aware` / `--type-check` from CLI usage to `oxlint` config `options`
- refresh lockfiles/config as needed

## Context
Aligned with the oxlint options migration introduced in oxc-project/oxc#19923.