### PR TITLE
fix: use system `node` on macOS to avoid native addon code signing crash

### DIFF
--- a/client/tools/lsp_helper.ts
+++ b/client/tools/lsp_helper.ts
@@ -12,7 +12,11 @@ function resolveNodeCommand(nodePath?: string): NodeCommandResolution {
     return { command: nodePath, useElectronAsNode: false };
   }
 
-  if (process.platform === "win32") {
+  // On macOS, using the Electron binary (process.execPath) with
+  // ELECTRON_RUN_AS_NODE fails when the server loads native .node addons:
+  // macOS code signing rejects dlopen because the Electron binary and the
+  // addon have different Team IDs.
+  if (process.platform === "win32" || process.platform === "darwin") {
     return { command: "node", useElectronAsNode: false };
   }
 

--- a/tests/unit/lsp_helper.spec.ts
+++ b/tests/unit/lsp_helper.spec.ts
@@ -79,13 +79,22 @@ suite("runExecutable", () => {
     strictEqual(result.args?.[1], "--lsp");
   });
 
-  test("should use process.execPath with ELECTRON_RUN_AS_NODE on non-Windows", () => {
+  test("should use process.execPath with ELECTRON_RUN_AS_NODE on Linux", () => {
     Object.defineProperty(process, "platform", { value: "linux" });
 
     const result = runExecutable("/path/to/server.js", tool);
 
     strictEqual(result.command, process.execPath);
     strictEqual(result.options?.env?.ELECTRON_RUN_AS_NODE, "1");
+  });
+
+  test("should use 'node' without ELECTRON_RUN_AS_NODE on macOS", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    const result = runExecutable("/path/to/server.js", tool);
+
+    strictEqual(result.command, "node");
+    strictEqual(result.options?.env?.ELECTRON_RUN_AS_NODE, undefined);
   });
 
   test("should use 'node' without ELECTRON_RUN_AS_NODE on Windows", () => {


### PR DESCRIPTION
## Summary

- On macOS, using the Electron binary (`process.execPath`) with `ELECTRON_RUN_AS_NODE=1` causes `dlopen` to fail when loading native `.node` addons (e.g. `@oxlint/binding-darwin-arm64`). macOS code signing rejects the load because the Electron binary and the addon have different Team IDs, resulting in SIGTRAP crashes.
- Adds `darwin` to the platform check that falls back to system `node` from PATH, alongside the existing `win32` check. The `process.execPath` optimization is preserved for Linux.

Related to #21

## Test plan

- [x] Verified fix resolves SIGTRAP crash on macOS with Cursor + sentry-javascript repo
- [x] Updated unit tests: renamed "non-Windows" test to "Linux", added macOS-specific test

🤖 Generated with [Claude Code](https://claude.com/claude-code)