### PR TITLE
docs: Improve the bug report template with some additional information.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,43 +5,49 @@ title: ""
 type: Bug
 ---
 
-### Confirmed this is a Bug for Editors
+### Confirm that this is a Bug for the editor extension, not the CLI
 
-- [ ] This Bug does not happen in CLI
+- [ ] This bug does not happen in the Oxlint/Oxfmt CLI
 - [ ] After restarting the editor, the bug still appears
 
-### Used Versions
+<!-- If you are able to see the same problem in the CLI, please report your issue at https://github.com/oxc-project/oxc -->
 
-<!-- Please fill out the versions, Hover over the Status Bar Icon to get the information as needed. -->
+### Versions used
+
+<!-- Please fill out the versions, hover over the Status Bar "oxc" in the bottom right to get the information as needed. -->
 
 ```
 VS Code extension: v0.0.0
 oxlint: v0.0.0
 oxfmt: v0.0.0
+VS Code version:
+Operating System and Version:
+Node Version: v0.0.0
+Node Manager: <!-- can be nvm, mise, asdf, vite-plus, etc, or you could have installed node directly -->
 ```
 
-### What Happened?
+### What happened?
 
 <!-- Please describe the issue you're experiencing and steps to reproduce the issue. -->
 
-### Reproduction Repo
+### Reproduction repo
 
-<!-- If this bug is related to oxlint / oxfmt CLI inconsistency -->
+<!-- If this bug is related to an oxlint / oxfmt CLI inconsistency, please provide a minimal git repository reproducing the issue, so we can resolve the problem for you more easily. -->
 
-### Output Channel Log
+### Output channel log
 
 <!--
   If you have a problem with oxlint / oxfmt, the output log could be helpful for us.
-  Set `oxc.trace.server` to `verbose` in your `.vscode/settings.json` for more information.
-  Warning: setting it to `verbose`, will output your file content too, make sure you do not include unwanted information.
+  Set `oxc.trace.server` to `verbose` in your `.vscode/settings.json` for more
+  information and then use "Oxc: Show Output Channel (Linter/Formatter)".
+  Warning: setting it to `verbose` will output your file contents as well, make sure you do not include confidential information. You may consider asking your AI agent of choice to redact the log for you before sharing it if you have concerns.
 -->
+
+<details>
+<summary>Click to expand</summary>
 
 ```
 // your log here
 ```
 
-### System Info
-
-- Operating System:
-- Node Manager: <!-- can be nvm, mise, and more, or you could have installed node directly -->
-- Node Version:
+</details>


### PR DESCRIPTION
- Put all the version reporting parts all in the same section.
- Collapse the output channel log section by default since it can be quite long.
- Link to the oxc repo for CLI issues.
- Misc phrasing changes/additions