### PR TITLE
ci: replace OXC_BOT_PAT with GitHub App tokens

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -30,9 +30,15 @@ jobs:
         run: |
           npm pkg set version="${NEW_VERSION}"
 
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.OXC_BOT_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "release: v${{ inputs.version }}${{ inputs.pre-release && ' [pre-release]' || '' }}"
           title: "release: v${{ inputs.version }}${{ inputs.pre-release && ' (pre-release)' || '' }}"
           branch: release/v${{ inputs.version }}


### PR DESCRIPTION
## Summary
- replace `OXC_BOT_PAT` workflow usage with `actions/create-github-app-token`
- use `APP_ID` and `APP_PRIVATE_KEY` to mint per-job GitHub App installation tokens
- keep existing workflow behavior for PR creation, release flows, comments, dispatches, and checkout-backed pushes
