### PR TITLE
fix(vite-plus): search for `node_modules/.bin` before resolving to native package

### DIFF
--- a/client/findBinary.ts
+++ b/client/findBinary.ts
@@ -91,7 +91,10 @@ export function clearWorkspacePackageJsonNodeModulesCache(): void {
 export async function searchProjectNodeModulesBin(
   binaryName: string,
 ): Promise<BinarySearchResult | undefined> {
-  // fallback to direct binary lookup in workspace node_modules/.bin
+  // try to find shared binary inside `node_modules/.bin` of each workspace folder
+  // This is required, because the project can use `vite-plus`,
+  // which has different environment variables for `oxlint` and `oxfmt`.
+  // Example: It will skip the `vite.config.ts` search without `VP_VERSION` env variable.
   const workspaceNodeModules = (workspace.workspaceFolders ?? []).map((folder) =>
     path.join(folder.uri.fsPath, "node_modules"),
   );
@@ -107,7 +110,7 @@ export async function searchProjectNodeModulesBin(
     return result2;
   }
 
-  // try to resolve via require.resolve
+  // fallback to direct binary lookupvia require.resolve
   try {
     const resolvedPath = replaceTargetFromMainToBin(
       require.resolve(binaryName, {
@@ -200,12 +203,15 @@ export async function searchGlobalNodeModulesBin(
 ): Promise<BinarySearchResult | undefined> {
   const globalPaths = globalNodeModulesPaths();
 
-  // fallback to direct binary lookup in global node_modules/.bin
+  // try to find shared binary inside `node_modules/.bin` of each workspace folder
+  // This is required, because the project can use `vite-plus`,
+  // which has different environment variables for `oxlint` and `oxfmt`.
+  // Example: It will skip the `vite.config.ts` search without `VP_VERSION` env variable.
   const result = await searchNodeModulesDefaultBinPath(binaryName, globalPaths);
   if (result) {
     return result;
   }
-  // try to resolve via require.resolve
+  // fallback to direct binary lookup via require.resolve
   try {
     const resolvedPath = replaceTargetFromMainToBin(
       require.resolve(binaryName, { paths: globalPaths }),

--- a/client/findBinary.ts
+++ b/client/findBinary.ts
@@ -91,17 +91,6 @@ export function clearWorkspacePackageJsonNodeModulesCache(): void {
 export async function searchProjectNodeModulesBin(
   binaryName: string,
 ): Promise<BinarySearchResult | undefined> {
-  // try to resolve via require.resolve
-  try {
-    const resolvedPath = replaceTargetFromMainToBin(
-      require.resolve(binaryName, {
-        paths: workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) ?? [],
-      }),
-      binaryName,
-    );
-    return { path: resolvedPath, loader: "node" };
-  } catch {}
-
   // fallback to direct binary lookup in workspace node_modules/.bin
   const workspaceNodeModules = (workspace.workspaceFolders ?? []).map((folder) =>
     path.join(folder.uri.fsPath, "node_modules"),
@@ -113,7 +102,21 @@ export async function searchProjectNodeModulesBin(
 
   // fallback to searching for package.json in workspace subfolders (monorepo support)
   const packageJsonNodeModules = await getWorkspacePackageJsonNodeModules();
-  return searchNodeModulesDefaultBinPath(binaryName, packageJsonNodeModules);
+  const result2 = await searchNodeModulesDefaultBinPath(binaryName, packageJsonNodeModules);
+  if (result2) {
+    return result2;
+  }
+
+  // try to resolve via require.resolve
+  try {
+    const resolvedPath = replaceTargetFromMainToBin(
+      require.resolve(binaryName, {
+        paths: workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) ?? [],
+      }),
+      binaryName,
+    );
+    return { path: resolvedPath, loader: "node" };
+  } catch {}
 }
 
 interface PnpApi {
@@ -196,6 +199,12 @@ export async function searchGlobalNodeModulesBin(
   binaryName: string,
 ): Promise<BinarySearchResult | undefined> {
   const globalPaths = globalNodeModulesPaths();
+
+  // fallback to direct binary lookup in global node_modules/.bin
+  const result = await searchNodeModulesDefaultBinPath(binaryName, globalPaths);
+  if (result) {
+    return result;
+  }
   // try to resolve via require.resolve
   try {
     const resolvedPath = replaceTargetFromMainToBin(
@@ -204,9 +213,6 @@ export async function searchGlobalNodeModulesBin(
     );
     return { path: resolvedPath, loader: "node" };
   } catch {}
-
-  // fallback to direct binary lookup in global node_modules/.bin
-  return searchNodeModulesDefaultBinPath(binaryName, globalPaths);
 }
 
 /**

--- a/client/findBinary.ts
+++ b/client/findBinary.ts
@@ -110,7 +110,7 @@ export async function searchProjectNodeModulesBin(
     return result2;
   }
 
-  // fallback to direct binary lookupvia require.resolve
+  // fallback to direct binary lookup via require.resolve
   try {
     const resolvedPath = replaceTargetFromMainToBin(
       require.resolve(binaryName, {


### PR DESCRIPTION
When the extension searches for `oxlint` or `oxfmt`, it first tried to resolve it via `require.resolve`, which resulted in a path like:

```
/home/user/project/node_modules/oxlint/bin/oxlint
/home/user/project/node_modules/.pnpm/oxlint@1.59.0_oxlint-tsgolint@0.20.0/node_modules/oxlint/bin/oxlint
```

This will execute the binaries with its native settings, without `vite-plus` context.
With this fix, it will search for `node_modules/.bin/oxlint` first, which was created by `vite-plus` itself.

related #215 