### PR TITLE
fix(formatter): remove defaultFormatter dependency for codeActionsOnSave

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To enable it as your default formatter, use a VS Code `settings.json` like:
 }
 ```
 
-To run Oxc formatting through VS Code code actions on save, configure `editor.codeActionsOnSave`:
+To run Oxc formatting through VS Code code actions on save, configure `editor.codeActionsOnSave`. No need to set `editor.defaultFormatter`:
 
 ```json
 {
@@ -52,12 +52,12 @@ To run Oxc formatting through VS Code code actions on save, configure `editor.co
 }
 ```
 
-Running formatting as a code action on save, allows to define the order of changes when both formatting and lint fixes are applied on save. For example, the below configuration will run the formatter first, and then apply lint fixes:
+Running formatting as a code action on save allows to define the order of changes when both formatting and lint fixes are applied on save. For example, the below configuration will run the formatter first, and then apply lint fixes:
 
 ```json
 {
-  "editor.defaultFormatter": "oxc.oxc-vscode",
-  "editor.formatOnSave": false, // disable default behavior
+  "editor.defaultFormatter": "oxc.oxc-vscode", // optional, recommended for manual formatting
+  "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.format.oxc": "always", // run formatter first
     "source.fixAll.oxc": "always" // run lint fixes after

--- a/client/commands.ts
+++ b/client/commands.ts
@@ -18,6 +18,7 @@ export const enum OxcCommands {
   // only for formatter.ts usage
   RestartServerFmt = `${commandPrefix}.restartServerFormatter`,
   ToggleEnableFmt = `${commandPrefix}.toggleEnableFormatter`,
+  FormatDocument = `${commandPrefix}.formatDocument`,
 
   // always available
   CopyDebugInfo = `${commandPrefix}.copyDebugInfo`,

--- a/client/tools/formatter.ts
+++ b/client/tools/formatter.ts
@@ -7,12 +7,16 @@ import {
   ConfigurationChangeEvent,
   languages,
   LogOutputChannel,
+  TextEdit,
   Uri,
+  window,
   workspace,
+  WorkspaceEdit,
 } from "vscode";
 
 import {
   ConfigurationParams,
+  DocumentFormattingRequest,
   DocumentSelector,
   ShowMessageNotification,
 } from "vscode-languageclient";
@@ -37,9 +41,9 @@ const formatCodeActionKind = CodeActionKind.Source.append("format.oxc");
 
 const formatCodeAction = new CodeAction("Format Document", formatCodeActionKind);
 formatCodeAction.command = {
-  command: "editor.action.formatDocument",
+  command: OxcCommands.FormatDocument,
   title: "Format Document",
-  tooltip: "Format the document using the default formatter",
+  tooltip: "Format the document with oxfmt",
 };
 
 // This list is not used as-is for implementation to determine whether formatting processing is possible.
@@ -314,11 +318,8 @@ export default class FormatterTool implements ToolInterface {
     const formatAction = languages.registerCodeActionsProvider(
       this.documentSelectors,
       {
-        provideCodeActions: (doc) => {
-          if (
-            configService.vsCodeConfig.enableOxfmt === false ||
-            workspace.getConfiguration("editor", doc).get("defaultFormatter") !== "oxc.oxc-vscode"
-          ) {
+        provideCodeActions: (_doc) => {
+          if (configService.vsCodeConfig.enableOxfmt === false) {
             return [];
           }
           return [formatCodeAction];
@@ -374,6 +375,31 @@ export default class FormatterTool implements ToolInterface {
     // Create the language client and start the client.
     this.client = new LanguageClient(languageClientName, serverOptions, clientOptions);
 
+    const formatCommand = commands.registerCommand(OxcCommands.FormatDocument, async () => {
+      const editor = window.activeTextEditor;
+      if (!editor || !this.client) return;
+
+      const doc = editor.document;
+      const editorConfig = workspace.getConfiguration("editor", doc);
+      const tabSize = editorConfig.get<number>("tabSize") ?? 4;
+      const insertSpaces = editorConfig.get<boolean>("insertSpaces") ?? true;
+
+      try {
+        const edits = await this.client.sendRequest(DocumentFormattingRequest.type, {
+          textDocument: { uri: doc.uri.toString() },
+          options: { tabSize, insertSpaces },
+        });
+
+        if (edits && edits.length > 0) {
+          const edit = new WorkspaceEdit();
+          edit.set(doc.uri, edits as TextEdit[]);
+          await workspace.applyEdit(edit);
+        }
+      } catch {
+        // Server might not support formatting for this document type
+      }
+    });
+
     const onNotificationDispose = this.client.onNotification(
       ShowMessageNotification.type,
       (params) => {
@@ -386,6 +412,7 @@ export default class FormatterTool implements ToolInterface {
       restartCommand.dispose();
       toggleEnable.dispose();
       formatAction.dispose();
+      formatCommand.dispose();
       onNotificationDispose.dispose();
     };
 


### PR DESCRIPTION
## Summary

Previously, using oxfmt via `editor.codeActionsOnSave` required setting `editor.defaultFormatter` to `"oxc.oxc-vscode"`, because the code action relied on VS Code's built-in `editor.action.formatDocument` command. This change removes that dependency.

## What changed

- **Custom format command**: Registered `oxc.formatDocument` that directly calls the LSP `textDocument/formatting` request via the language client, bypassing the need for `editor.defaultFormatter`
- **Removed `defaultFormatter` check**: The code actions provider no longer checks whether `editor.defaultFormatter` is set to `"oxc.oxc-vscode"`
- **Updated README**: Clarified that `editor.defaultFormatter` is now optional when using `codeActionsOnSave`, and is only recommended for manual formatting

## Test plan

- [ ] `source.format.oxc` in `codeActionsOnSave` works without setting `editor.defaultFormatter`
- [ ] `editor.formatOnSave` with `editor.defaultFormatter` set to `"oxc.oxc-vscode"` still works
- [ ] Manual formatting via `Format Document` command still works