### PR TITLE
fix: load server envs from interactive shell env

### DIFF
--- a/client/tools/formatter.ts
+++ b/client/tools/formatter.ts
@@ -331,7 +331,7 @@ export default class FormatterTool implements ToolInterface {
 
     outputChannel.info(`Using server binary at: ${binary?.path}`);
 
-    const run: Executable = runExecutable(
+    const run: Executable = await runExecutable(
       binary,
       configService.vsCodeConfig.useExecPath,
       configService.vsCodeConfig.nodePath,

--- a/client/tools/linter.ts
+++ b/client/tools/linter.ts
@@ -119,7 +119,7 @@ export default class LinterTool implements ToolInterface {
       await this.client.sendRequest(ExecuteCommandRequest.type, params);
     });
 
-    const run: Executable = runExecutable(
+    const run: Executable = await runExecutable(
       binary,
       configService.vsCodeConfig.useExecPath,
       configService.vsCodeConfig.nodePath,

--- a/client/tools/lsp_helper.ts
+++ b/client/tools/lsp_helper.ts
@@ -40,15 +40,25 @@ async function getInteractiveShellEnv(): Promise<Record<string, string | undefin
     // POSIX shells
     // Run the shell as a login shell to get the environment variables. The `-i` flag is for interactive shell, which is needed to load the shell configuration files.
     // The `-l` flag is for login shell, which is needed to load the environment variables defined in the shell configuration files.
-    const { stdout } = await execFileAsync(shell, ["-ilc", "env -0"], {
-      env: {
-        HOME: process.env.HOME,
+    const { stdout } = await execFileAsync(
+      shell,
+      ["-ilc", 'echo -n "_ENV_DELIMITER_"; command env -0; echo -n "_ENV_DELIMITER_"; exit'],
+      {
+        env: {
+          HOME: process.env.HOME,
+        },
+        timeout: 5000,
       },
-      timeout: 5000,
-    });
+    );
+
+    const envsOutput = stdout.split("_ENV_DELIMITER_")[1] ?? "";
+    if (!envsOutput) {
+      // If the output is empty, return the current process.env as a fallback.
+      return { ...process.env };
+    }
 
     const env: Record<string, string | undefined> = {};
-    for (const entry of stdout.split("\0")) {
+    for (const entry of envsOutput.split("\0")) {
       if (!entry) continue;
 
       const i = entry.indexOf("=");

--- a/client/tools/lsp_helper.ts
+++ b/client/tools/lsp_helper.ts
@@ -2,16 +2,95 @@ import * as path from "node:path";
 import { LogOutputChannel, window } from "vscode";
 import { Executable, MessageType, ShowMessageParams } from "vscode-languageclient/node";
 import type { BinarySearchResult } from "../findBinary";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
-export function runExecutable(
+const execFileAsync = promisify(execFile);
+
+let cachedEnv: Record<string, string> | undefined;
+
+/***
+ * Get the shell environment variables by running a login shell and executing `env -0`.
+ * This is necessary because the VSCode extension host process may not have the same environment variables as the user's shell,
+ * which can lead to issues when running the language server that rely on certain environment variables.
+ * e.g., PATH for starting the wrapper npm/pnpm node script like ` exec node  "$basedir/../oxlint/bin/oxlint" "$@"`.
+ *
+ * Mac/Linux GUI shells (which does happen in VS Code context, because of Electron) do not load `.bashrc` or `.zshrc` for non-interactive shells,
+ * and thus the language server fails to start with "command not found: node".
+ */
+export async function getShellEnv(): Promise<Record<string, string>> {
+  if (cachedEnv) {
+    return cachedEnv;
+  }
+
+  const shell = process.env.SHELL ?? "/bin/bash";
+
+  // POSIX shells
+  if (process.platform == "win32") {
+    // windows electron app does not have the problem of individual shell environment, as it inherits the environment from the parent process,
+    cachedEnv = { ...process.env } as Record<string, string>;
+    return cachedEnv;
+  }
+  // Run the shell as a login shell to get the environment variables. The `-i` flag is for interactive shell, which is needed to load the shell configuration files.
+  // The `-l` flag is for login shell, which is needed to load the environment variables defined in the shell configuration files.
+  const { stdout } = await execFileAsync(shell, ["-ilc", "env -0"], {
+    env: {
+      HOME: process.env.HOME,
+    },
+  });
+
+  cachedEnv = {};
+
+  for (const entry of stdout.split("\0")) {
+    if (!entry) continue;
+
+    const i = entry.indexOf("=");
+
+    if (i === -1) continue;
+
+    cachedEnv[entry.slice(0, i)] = entry.slice(i + 1);
+  }
+
+  return cachedEnv;
+}
+
+export async function runExecutable(
   binary: BinarySearchResult,
   useExecPath: boolean = false,
   nodePath?: string,
   tsgolintPath?: string,
   suppressProgramErrors?: boolean,
-): Executable {
+): Promise<Executable> {
+  const processEnv = process.env;
+  const shellEnv = await getShellEnv();
+
+  // only for debugging purpose
+  {
+    if (Object.keys(processEnv).length !== Object.keys(shellEnv).length) {
+      const missingInProcessEnv = Object.keys(shellEnv).filter((key) => !(key in processEnv));
+      const missingInShellEnv = Object.keys(processEnv).filter((key) => !(key in shellEnv));
+
+      console.warn("Process env and shell env have different number of keys", {
+        missingInProcessEnv,
+        missingInShellEnv,
+      });
+    }
+
+    if (processEnv.PATH !== shellEnv.PATH) {
+      const processEnvPATH = processEnv.PATH?.split(path.delimiter) ?? [];
+      const shellEnvPATH = shellEnv.PATH?.split(path.delimiter) ?? [];
+      const missingInProcessEnvPATH = shellEnvPATH.filter((p) => !processEnvPATH.includes(p));
+      const missingInShellEnvPATH = processEnvPATH.filter((p) => !shellEnvPATH.includes(p));
+
+      console.warn("Process env and shell env have different PATH values", {
+        missingInProcessEnvPATH,
+        missingInShellEnvPATH,
+      });
+    }
+  }
+
   const serverEnv: Record<string, string> = {
-    ...process.env,
+    ...shellEnv,
     RUST_LOG: process.env.RUST_LOG || "info", // Keep for backward compatibility for a while
     OXC_LOG: process.env.OXC_LOG || "info",
     NO_COLOR: "1",

--- a/client/tools/lsp_helper.ts
+++ b/client/tools/lsp_helper.ts
@@ -7,25 +7,25 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-let cachedEnv: Promise<Record<string, string>> | undefined;
+let cachedEnv: Promise<Record<string, string | undefined>> | undefined;
 
-/***
+/**
  * Get the shell environment variables by running a login shell and executing `env -0`.
  * This is necessary because the VSCode extension host process may not have the same environment variables as the user's shell,
  * which can lead to issues when running the language server that rely on certain environment variables.
  * e.g., PATH for starting the wrapper npm/pnpm node script like ` exec node  "$basedir/../oxlint/bin/oxlint" "$@"`.
  *
- * Mac/Linux GUI shells (which does happen in VS Code context, because of Electron) do not load `.bashrc` or `.zshrc` for non-interactive shells,
- * and thus the language server fails to start with "command not found: node".
+ * On macOS/Linux, GUI-launched processes such as VS Code under Electron do not load `.bashrc` or `.zshrc`
+ * the way an interactive shell does, so the language server can fail to start with "command not found: node".
  */
-export async function getShellEnv(): Promise<Record<string, string>> {
+export async function getShellEnv(): Promise<Record<string, string | undefined>> {
   if (cachedEnv) {
     return cachedEnv;
   }
 
-  // windows electron app does not have the problem of individual shell environment, as it inherits the environment from the parent process,
+  // windows electron app does not have the problem of individual shell environment, as it inherits the environment from the parent process.
   if (process.platform === "win32") {
-    cachedEnv = Promise.resolve({ ...process.env } as Record<string, string>);
+    cachedEnv = Promise.resolve({ ...process.env });
     return cachedEnv;
   }
 
@@ -33,7 +33,7 @@ export async function getShellEnv(): Promise<Record<string, string>> {
   return cachedEnv;
 }
 
-async function getInteractiveShellEnv(): Promise<Record<string, string>> {
+async function getInteractiveShellEnv(): Promise<Record<string, string | undefined>> {
   const shell = process.env.SHELL ?? "/bin/bash";
 
   try {
@@ -47,7 +47,7 @@ async function getInteractiveShellEnv(): Promise<Record<string, string>> {
       timeout: 5000,
     });
 
-    const env: Record<string, string> = {};
+    const env: Record<string, string | undefined> = {};
     for (const entry of stdout.split("\0")) {
       if (!entry) continue;
 
@@ -61,7 +61,7 @@ async function getInteractiveShellEnv(): Promise<Record<string, string>> {
     return env;
   } catch {
     // If there is an error (e.g., timeout, shell not found, etc.), return the current process.env as a fallback.
-    return { ...process.env } as Record<string, string>;
+    return { ...process.env };
   }
 }
 

--- a/client/tools/lsp_helper.ts
+++ b/client/tools/lsp_helper.ts
@@ -7,7 +7,7 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-let cachedEnv: Record<string, string> | undefined;
+let cachedEnv: Promise<Record<string, string>> | undefined;
 
 /***
  * Get the shell environment variables by running a login shell and executing `env -0`.
@@ -23,35 +23,46 @@ export async function getShellEnv(): Promise<Record<string, string>> {
     return cachedEnv;
   }
 
-  const shell = process.env.SHELL ?? "/bin/bash";
-
-  // POSIX shells
-  if (process.platform == "win32") {
-    // windows electron app does not have the problem of individual shell environment, as it inherits the environment from the parent process,
-    cachedEnv = { ...process.env } as Record<string, string>;
+  // windows electron app does not have the problem of individual shell environment, as it inherits the environment from the parent process,
+  if (process.platform === "win32") {
+    cachedEnv = Promise.resolve({ ...process.env } as Record<string, string>);
     return cachedEnv;
   }
-  // Run the shell as a login shell to get the environment variables. The `-i` flag is for interactive shell, which is needed to load the shell configuration files.
-  // The `-l` flag is for login shell, which is needed to load the environment variables defined in the shell configuration files.
-  const { stdout } = await execFileAsync(shell, ["-ilc", "env -0"], {
-    env: {
-      HOME: process.env.HOME,
-    },
-  });
 
-  cachedEnv = {};
-
-  for (const entry of stdout.split("\0")) {
-    if (!entry) continue;
-
-    const i = entry.indexOf("=");
-
-    if (i === -1) continue;
-
-    cachedEnv[entry.slice(0, i)] = entry.slice(i + 1);
-  }
-
+  cachedEnv = getInteractiveShellEnv();
   return cachedEnv;
+}
+
+async function getInteractiveShellEnv(): Promise<Record<string, string>> {
+  const shell = process.env.SHELL ?? "/bin/bash";
+
+  try {
+    // POSIX shells
+    // Run the shell as a login shell to get the environment variables. The `-i` flag is for interactive shell, which is needed to load the shell configuration files.
+    // The `-l` flag is for login shell, which is needed to load the environment variables defined in the shell configuration files.
+    const { stdout } = await execFileAsync(shell, ["-ilc", "env -0"], {
+      env: {
+        HOME: process.env.HOME,
+      },
+      timeout: 5000,
+    });
+
+    const env: Record<string, string> = {};
+    for (const entry of stdout.split("\0")) {
+      if (!entry) continue;
+
+      const i = entry.indexOf("=");
+
+      if (i === -1) continue;
+
+      env[entry.slice(0, i)] = entry.slice(i + 1);
+    }
+
+    return env;
+  } catch {
+    // If there is an error (e.g., timeout, shell not found, etc.), return the current process.env as a fallback.
+    return { ...process.env } as Record<string, string>;
+  }
 }
 
 export async function runExecutable(
@@ -61,33 +72,7 @@ export async function runExecutable(
   tsgolintPath?: string,
   suppressProgramErrors?: boolean,
 ): Promise<Executable> {
-  const processEnv = process.env;
   const shellEnv = await getShellEnv();
-
-  // only for debugging purpose
-  {
-    if (Object.keys(processEnv).length !== Object.keys(shellEnv).length) {
-      const missingInProcessEnv = Object.keys(shellEnv).filter((key) => !(key in processEnv));
-      const missingInShellEnv = Object.keys(processEnv).filter((key) => !(key in shellEnv));
-
-      console.warn("Process env and shell env have different number of keys", {
-        missingInProcessEnv,
-        missingInShellEnv,
-      });
-    }
-
-    if (processEnv.PATH !== shellEnv.PATH) {
-      const processEnvPATH = processEnv.PATH?.split(path.delimiter) ?? [];
-      const shellEnvPATH = shellEnv.PATH?.split(path.delimiter) ?? [];
-      const missingInProcessEnvPATH = shellEnvPATH.filter((p) => !processEnvPATH.includes(p));
-      const missingInShellEnvPATH = processEnvPATH.filter((p) => !shellEnvPATH.includes(p));
-
-      console.warn("Process env and shell env have different PATH values", {
-        missingInProcessEnvPATH,
-        missingInShellEnvPATH,
-      });
-    }
-  }
 
   const serverEnv: Record<string, string> = {
     ...shellEnv,
@@ -118,7 +103,7 @@ export async function runExecutable(
 
   if (path.isAbsolute(nodeCommand)) {
     const nodeDir = path.dirname(nodeCommand);
-    serverEnv.PATH = `${nodeDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`;
+    serverEnv.PATH = `${nodeDir}${path.delimiter}${serverEnv.PATH ?? ""}`;
   }
 
   const isWindows = process.platform === "win32";

--- a/client/tools/lsp_helper.ts
+++ b/client/tools/lsp_helper.ts
@@ -42,7 +42,7 @@ async function getInteractiveShellEnv(): Promise<Record<string, string | undefin
     // The `-l` flag is for login shell, which is needed to load the environment variables defined in the shell configuration files.
     const { stdout } = await execFileAsync(
       shell,
-      ["-ilc", 'echo -n "_ENV_DELIMITER_"; command env -0; echo -n "_ENV_DELIMITER_"; exit'],
+      ["-ilc", 'echo -n "_ENV_DELIMITER_"; command env; echo -n "_ENV_DELIMITER_"; exit'],
       {
         env: {
           HOME: process.env.HOME,
@@ -58,7 +58,7 @@ async function getInteractiveShellEnv(): Promise<Record<string, string | undefin
     }
 
     const env: Record<string, string | undefined> = {};
-    for (const entry of envsOutput.split("\0")) {
+    for (const entry of envsOutput.split("\n")) {
       if (!entry) continue;
 
       const i = entry.indexOf("=");

--- a/tests/unit/lsp_helper.spec.ts
+++ b/tests/unit/lsp_helper.spec.ts
@@ -11,8 +11,8 @@ suite("runExecutable", () => {
     process.env = originalEnv;
   });
 
-  test("should create Node.js executable for .js files", () => {
-    const result = runExecutable({
+  test("should create Node.js executable for .js files", async () => {
+    const result = await runExecutable({
       path: "/path/to/server.js",
       loader: "node",
     });
@@ -22,8 +22,8 @@ suite("runExecutable", () => {
     strictEqual(result.args?.[1], "--lsp");
   });
 
-  test("should create Node.js executable for .cjs files", () => {
-    const result = runExecutable({
+  test("should create Node.js executable for .cjs files", async () => {
+    const result = await runExecutable({
       path: "/path/to/server.cjs",
       loader: "node",
     });
@@ -33,8 +33,8 @@ suite("runExecutable", () => {
     strictEqual(result.args?.[1], "--lsp");
   });
 
-  test("should create Node.js executable for .mjs files", () => {
-    const result = runExecutable({
+  test("should create Node.js executable for .mjs files", async () => {
+    const result = await runExecutable({
       path: "/path/to/server.mjs",
       loader: "node",
     });
@@ -44,8 +44,8 @@ suite("runExecutable", () => {
     strictEqual(result.args?.[1], "--lsp");
   });
 
-  test("should create binary executable for non-Node files", () => {
-    const result = runExecutable({
+  test("should create binary executable for non-Node files", async () => {
+    const result = await runExecutable({
       path: "/path/to/oxc-language-server",
       loader: "native",
     });
@@ -60,10 +60,10 @@ suite("runExecutable", () => {
     strictEqual(result.options?.shell, process.platform === "win32");
   });
 
-  test("should use shell on Windows for binary executables", () => {
+  test("should use shell on Windows for binary executables", async () => {
     Object.defineProperty(process, "platform", { value: "win32" });
 
-    const result = runExecutable({
+    const result = await runExecutable({
       path: "C:\\Path With Spaces\\oxc-language-server",
       loader: "native",
     });
@@ -71,11 +71,11 @@ suite("runExecutable", () => {
     strictEqual(result.options?.shell, true);
   });
 
-  test("should prepend nodePath to PATH", () => {
+  test("should prepend nodePath to PATH", async () => {
     Object.defineProperty(process, "platform", { value: "linux" });
     process.env.PATH = "/usr/bin:/bin";
 
-    const result = runExecutable(
+    const result = await runExecutable(
       {
         path: "/path/to/server.js",
         loader: "node",
@@ -88,10 +88,10 @@ suite("runExecutable", () => {
     strictEqual(result.options?.env?.PATH, "/custom/node/bin:/usr/bin:/bin");
   });
 
-  test("should set path in quotes on Windows for binary executables", () => {
+  test("should set path in quotes on Windows for binary executables", async () => {
     Object.defineProperty(process, "platform", { value: "win32" });
 
-    const result = runExecutable({
+    const result = await runExecutable({
       path: "C:\\Path With Spaces\\oxc-language-server",
       loader: "native",
     });
@@ -99,8 +99,8 @@ suite("runExecutable", () => {
     strictEqual(result.command, '"C:\\Path With Spaces\\oxc-language-server"');
   });
 
-  test("should use the provided node path for Node.js executables", () => {
-    const result = runExecutable(
+  test("should use the provided node path for Node.js executables", async () => {
+    const result = await runExecutable(
       {
         path: "/path/to/server.js",
         loader: "node",
@@ -114,8 +114,8 @@ suite("runExecutable", () => {
     strictEqual(result.args?.[1], "--lsp");
   });
 
-  test("should use 'execPath' with ELECTRON_RUN_AS_NODE", () => {
-    const result = runExecutable(
+  test("should use 'execPath' with ELECTRON_RUN_AS_NODE", async () => {
+    const result = await runExecutable(
       {
         path: "/path/to/server.js",
         loader: "node",
@@ -127,8 +127,8 @@ suite("runExecutable", () => {
     strictEqual(result.options?.env?.ELECTRON_RUN_AS_NODE, "1");
   });
 
-  test("should not set ELECTRON_RUN_AS_NODE server env", () => {
-    const result = runExecutable(
+  test("should not set ELECTRON_RUN_AS_NODE server env", async () => {
+    const result = await runExecutable(
       {
         path: "/path/to/server.js",
         loader: "node",
@@ -138,8 +138,8 @@ suite("runExecutable", () => {
     strictEqual(result.options?.env?.ELECTRON_RUN_AS_NODE, undefined);
   });
 
-  test("should set yarn PnP loader path when provided", () => {
-    const result = runExecutable({
+  test("should set yarn PnP loader path when provided", async () => {
+    const result = await runExecutable({
       path: "/path/to/server.js",
       loader: "node",
       yarnPnpLoaderPath: "/path/to/.pnp.cjs",

--- a/tests/unit/lsp_helper.spec.ts
+++ b/tests/unit/lsp_helper.spec.ts
@@ -85,7 +85,7 @@ suite("runExecutable", () => {
     );
 
     strictEqual(result.command, "/custom/node/bin/node");
-    strictEqual(result.options?.env?.PATH, "/custom/node/bin:/usr/bin:/bin");
+    strictEqual(result.options?.env?.PATH?.includes("/custom/node/bin:"), true);
   });
 
   test("should set path in quotes on Windows for binary executables", async () => {


### PR DESCRIPTION
> This PR addresses a startup failure where the language server (`oxlint`/`oxfmt`) cannot find `node` on the PATH when the VS Code Electron process is launched from a GUI on macOS/Linux.

closes https://github.com/oxc-project/oxc-vscode/issues/255
closes https://github.com/oxc-project/oxc-vscode/issues/21