### PR TITLE
test: update/remove fixAll command tests

### DIFF
--- a/tests/integration/commands.spec.ts
+++ b/tests/integration/commands.spec.ts
@@ -118,7 +118,7 @@ suite("commands", () => {
     }
     const edit = new WorkspaceEdit();
     edit.createFile(fileUri, {
-      contents: Buffer.from("/* 😊 */debugger;"),
+      contents: Buffer.from("/* 😊 */if (foo == NaN) {}"),
       overwrite: true,
     });
 
@@ -131,6 +131,6 @@ suite("commands", () => {
 
     const content = await workspace.fs.readFile(fileUri);
 
-    strictEqual(content.toString(), "/* 😊 */");
+    strictEqual(content.toString(), "/* 😊 */if (isNaN(foo)) {}");
   });
 });

--- a/tests/integration/e2e_server_linter.spec.ts
+++ b/tests/integration/e2e_server_linter.spec.ts
@@ -13,6 +13,7 @@ import {
   activateExtension,
   createOxlintConfiguration,
   deleteFixtures,
+  deleteOxlintConfiguration,
   fixturesWorkspaceUri,
   getDiagnostics,
   getDiagnosticsWithoutClose,
@@ -176,6 +177,7 @@ suite("E2E Server Linter", () => {
       DiagnosticSeverity.Error,
       "Expect changed severity to be error",
     );
+    await deleteOxlintConfiguration();
   });
 
   test("nested configs severity", async () => {

--- a/tests/integration/e2e_server_linter.spec.ts
+++ b/tests/integration/e2e_server_linter.spec.ts
@@ -1,6 +1,5 @@
 import { strictEqual } from "assert";
 import {
-  commands,
   DiagnosticSeverity,
   languages,
   Position,
@@ -177,52 +176,6 @@ suite("E2E Server Linter", () => {
       DiagnosticSeverity.Error,
       "Expect changed severity to be error",
     );
-  });
-
-  // We can check the changed with kind with `vscode.executeCodeActionProvider`
-  // but to be safe that everything works, we will check the applied changes.
-  // This way we can be sure that everything works as expected.
-  test("auto detect changing `fixKind` with fixAll command", async () => {
-    await workspace.getConfiguration("oxc").update("fixKind", "safe_fix");
-    await sleep(500);
-
-    const originalContent = "if (x === -0) { bar();}";
-    await createOxlintConfiguration({
-      rules: {
-        "no-compare-neg-zero": "error",
-      },
-    });
-
-    const edit = new WorkspaceEdit();
-
-    edit.createFile(fileUri, {
-      contents: Buffer.from(originalContent),
-      overwrite: true,
-    });
-
-    await workspace.applyEdit(edit);
-    await window.showTextDocument(fileUri);
-    await commands.executeCommand("oxc.fixAll", {
-      uri: fileUri.toString(),
-    });
-    await workspace.saveAll();
-
-    const content = await workspace.fs.readFile(fileUri);
-
-    strictEqual(content.toString(), originalContent);
-    await workspace.getConfiguration("oxc").update("fixKind", undefined);
-    // wait for server to update the internal linter
-    await sleep(500);
-    await workspace.saveAll();
-
-    await commands.executeCommand("oxc.fixAll", {
-      uri: fileUri.toString(),
-    });
-    await sleep(500);
-    await workspace.saveAll();
-    const contentWithFixAll = await workspace.fs.readFile(fileUri);
-
-    strictEqual(contentWithFixAll.toString(), "if (Object.is(x, -0)) { bar();}");
   });
 
   test("nested configs severity", async () => {

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -96,6 +96,10 @@ export async function createOxlintConfiguration(configuration: OxlintConfig): Pr
   await workspace.applyEdit(edit);
 }
 
+export async function deleteOxlintConfiguration(): Promise<void> {
+  await workspace.fs.delete(rootOxlintConfigUri, { useTrash: false });
+}
+
 // in multi folder setup we want to load the fixtures into the second folder.
 // the first folder should be already covered by the single folder setup.
 export function fixturesWorkspaceUri(): Uri {


### PR DESCRIPTION
Oxlint v1.64.0 does not apply suggestions now.
Updated the command test to target a safe fix rule.
Removed the "changing fixKind for command" tests, because now only safe fixes are applied.

upstream PR https://github.com/oxc-project/oxc/pull/22195/