### PR TITLE
fix: search global node_modules with interactive shell

### DIFF
--- a/client/findBinary.ts
+++ b/client/findBinary.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { env } from "node:process";
 import { Uri, workspace } from "vscode";
 import { validateSafeBinaryPath } from "./PathValidator";
+import { getShellEnv } from "./utils";
 
 export type BinarySearchResult = {
   path: string;
@@ -202,7 +203,7 @@ export async function searchYarnPnpBin(
 export async function searchGlobalNodeModulesBin(
   binaryName: string,
 ): Promise<BinarySearchResult | undefined> {
-  const globalPaths = globalNodeModulesPaths();
+  const globalPaths = await globalNodeModulesPaths();
 
   // try to find shared binary inside `node_modules/.bin` of each workspace folder
   // This is required, because the project can use `vite-plus`,
@@ -321,9 +322,9 @@ export async function searchSettingsBin(
 }
 
 // copied from: https://github.com/biomejs/biome-vscode/blob/ae9b6df2254d0ff8ee9d626554251600eb2ca118/src/locator.ts#L28-L49
-function globalNodeModulesPaths(): string[] {
-  const npmGlobalNodeModulesPath = safeSpawnSync("npm", ["root", "-g"]);
-  const pnpmGlobalNodeModulesPath = safeSpawnSync("pnpm", ["root", "-g"]);
+async function globalNodeModulesPaths(): Promise<string[]> {
+  const npmGlobalNodeModulesPath = await safeSpawnSync("npm", ["root", "-g"]);
+  const pnpmGlobalNodeModulesPath = await safeSpawnSync("pnpm", ["root", "-g"]);
   const bunGlobalNodeModulesPath = path.resolve(homedir(), ".bun/install/global/node_modules");
 
   return [npmGlobalNodeModulesPath, pnpmGlobalNodeModulesPath, bunGlobalNodeModulesPath].filter(
@@ -333,13 +334,17 @@ function globalNodeModulesPaths(): string[] {
 
 // only use this function with internal code, because it executes shell commands
 // which could be a security risk if the command or args are user-controlled
-const safeSpawnSync = (command: string, args: readonly string[] = []): string | undefined => {
+const safeSpawnSync = async (
+  command: string,
+  args: readonly string[] = [],
+): Promise<string | undefined> => {
   let output: string | undefined;
 
   try {
     const result = spawnSync(command, args, {
       shell: true,
       encoding: "utf8",
+      env: await getShellEnv(),
     });
 
     if (result.error || result.status !== 0) {

--- a/client/findBinary.ts
+++ b/client/findBinary.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { env } from "node:process";
 import { Uri, workspace } from "vscode";
 import { validateSafeBinaryPath } from "./PathValidator";
-import { getShellEnv } from "./utils";
+import { getShellEnv } from "./getShellEnv";
 
 export type BinarySearchResult = {
   path: string;

--- a/client/getShellEnv.ts
+++ b/client/getShellEnv.ts
@@ -6,10 +6,11 @@ const execFileAsync = promisify(execFile);
 let cachedEnv: Promise<Record<string, string | undefined>> | undefined;
 
 /**
- * Get the shell environment variables by running a login shell and executing `env -0`.
+ * Get the shell environment variables by running a login shell and executing `env`.
  * This is necessary because the VSCode extension host process may not have the same environment variables as the user's shell,
  * which can lead to issues when running the language server that rely on certain environment variables.
  * e.g., PATH for starting the wrapper npm/pnpm node script like ` exec node  "$basedir/../oxlint/bin/oxlint" "$@"`.
+ * It also helps to get the right global node_modules paths.
  *
  * On macOS/Linux, GUI-launched processes such as VS Code under Electron do not load `.bashrc` or `.zshrc`
  * the way an interactive shell does, so the language server can fail to start with "command not found: node".

--- a/client/tools/lsp_helper.ts
+++ b/client/tools/lsp_helper.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import { LogOutputChannel, window } from "vscode";
 import { Executable, MessageType, ShowMessageParams } from "vscode-languageclient/node";
 import type { BinarySearchResult } from "../findBinary";
-import { getShellEnv } from "../utils";
+import { getShellEnv } from "../getShellEnv";
 
 export async function runExecutable(
   binary: BinarySearchResult,

--- a/client/tools/lsp_helper.ts
+++ b/client/tools/lsp_helper.ts
@@ -2,78 +2,7 @@ import * as path from "node:path";
 import { LogOutputChannel, window } from "vscode";
 import { Executable, MessageType, ShowMessageParams } from "vscode-languageclient/node";
 import type { BinarySearchResult } from "../findBinary";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
-
-let cachedEnv: Promise<Record<string, string | undefined>> | undefined;
-
-/**
- * Get the shell environment variables by running a login shell and executing `env -0`.
- * This is necessary because the VSCode extension host process may not have the same environment variables as the user's shell,
- * which can lead to issues when running the language server that rely on certain environment variables.
- * e.g., PATH for starting the wrapper npm/pnpm node script like ` exec node  "$basedir/../oxlint/bin/oxlint" "$@"`.
- *
- * On macOS/Linux, GUI-launched processes such as VS Code under Electron do not load `.bashrc` or `.zshrc`
- * the way an interactive shell does, so the language server can fail to start with "command not found: node".
- */
-export async function getShellEnv(): Promise<Record<string, string | undefined>> {
-  if (cachedEnv) {
-    return cachedEnv;
-  }
-
-  // windows electron app does not have the problem of individual shell environment, as it inherits the environment from the parent process.
-  if (process.platform === "win32") {
-    cachedEnv = Promise.resolve({ ...process.env });
-    return cachedEnv;
-  }
-
-  cachedEnv = getInteractiveShellEnv();
-  return cachedEnv;
-}
-
-async function getInteractiveShellEnv(): Promise<Record<string, string | undefined>> {
-  const shell = process.env.SHELL ?? "/bin/bash";
-
-  try {
-    // POSIX shells
-    // Run the shell as a login shell to get the environment variables. The `-i` flag is for interactive shell, which is needed to load the shell configuration files.
-    // The `-l` flag is for login shell, which is needed to load the environment variables defined in the shell configuration files.
-    const { stdout } = await execFileAsync(
-      shell,
-      ["-ilc", 'echo -n "_ENV_DELIMITER_"; command env; echo -n "_ENV_DELIMITER_"; exit'],
-      {
-        env: {
-          HOME: process.env.HOME,
-        },
-        timeout: 5000,
-      },
-    );
-
-    const envsOutput = stdout.split("_ENV_DELIMITER_")[1] ?? "";
-    if (!envsOutput) {
-      // If the output is empty, return the current process.env as a fallback.
-      return { ...process.env };
-    }
-
-    const env: Record<string, string | undefined> = {};
-    for (const entry of envsOutput.split("\n")) {
-      if (!entry) continue;
-
-      const i = entry.indexOf("=");
-
-      if (i === -1) continue;
-
-      env[entry.slice(0, i)] = entry.slice(i + 1);
-    }
-
-    return env;
-  } catch {
-    // If there is an error (e.g., timeout, shell not found, etc.), return the current process.env as a fallback.
-    return { ...process.env };
-  }
-}
+import { getShellEnv } from "../utils";
 
 export async function runExecutable(
   binary: BinarySearchResult,

--- a/client/utils.ts
+++ b/client/utils.ts
@@ -1,0 +1,72 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+let cachedEnv: Promise<Record<string, string | undefined>> | undefined;
+
+/**
+ * Get the shell environment variables by running a login shell and executing `env -0`.
+ * This is necessary because the VSCode extension host process may not have the same environment variables as the user's shell,
+ * which can lead to issues when running the language server that rely on certain environment variables.
+ * e.g., PATH for starting the wrapper npm/pnpm node script like ` exec node  "$basedir/../oxlint/bin/oxlint" "$@"`.
+ *
+ * On macOS/Linux, GUI-launched processes such as VS Code under Electron do not load `.bashrc` or `.zshrc`
+ * the way an interactive shell does, so the language server can fail to start with "command not found: node".
+ */
+export async function getShellEnv(): Promise<Record<string, string | undefined>> {
+  if (cachedEnv) {
+    return cachedEnv;
+  }
+
+  // windows electron app does not have the problem of individual shell environment, as it inherits the environment from the parent process.
+  if (process.platform === "win32") {
+    cachedEnv = Promise.resolve({ ...process.env });
+    return cachedEnv;
+  }
+
+  cachedEnv = getInteractiveShellEnv();
+  return cachedEnv;
+}
+
+async function getInteractiveShellEnv(): Promise<Record<string, string | undefined>> {
+  const shell = process.env.SHELL ?? "/bin/bash";
+
+  try {
+    // POSIX shells
+    // Run the shell as a login shell to get the environment variables. The `-i` flag is for interactive shell, which is needed to load the shell configuration files.
+    // The `-l` flag is for login shell, which is needed to load the environment variables defined in the shell configuration files.
+    const { stdout } = await execFileAsync(
+      shell,
+      ["-ilc", 'echo -n "_ENV_DELIMITER_"; command env; echo -n "_ENV_DELIMITER_"; exit'],
+      {
+        env: {
+          HOME: process.env.HOME,
+        },
+        timeout: 5000,
+      },
+    );
+
+    const envsOutput = stdout.split("_ENV_DELIMITER_")[1] ?? "";
+    if (!envsOutput) {
+      // If the output is empty, return the current process.env as a fallback.
+      return { ...process.env };
+    }
+
+    const env: Record<string, string | undefined> = {};
+    for (const entry of envsOutput.split("\n")) {
+      if (!entry) continue;
+
+      const i = entry.indexOf("=");
+
+      if (i === -1) continue;
+
+      env[entry.slice(0, i)] = entry.slice(i + 1);
+    }
+
+    return env;
+  } catch {
+    // If there is an error (e.g., timeout, shell not found, etc.), return the current process.env as a fallback.
+    return { ...process.env };
+  }
+}


### PR DESCRIPTION
## Pull request overview

This PR centralizes shell-environment discovery into a shared utility and uses it when resolving binaries (notably global `node_modules/.bin`) so the extension can find tools installed in PATHs set by the user’s interactive/login shell.

closes #272 