### PR TITLE
fix: reorder configuration properties to avoid console warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,15 +121,6 @@
           "default": "onType",
           "markdownDescription": "Run the linter on save (onSave) or on type (onType)"
         },
-        "oxc.enable": {
-          "type": [
-            "boolean",
-            "null"
-          ],
-          "default": null,
-          "scope": "window",
-          "markdownDescription": "This is a master toggle for both `oxc.enable.oxlint` and `oxc.enable.oxfmt`."
-        },
         "oxc.enable.oxlint": {
           "type": "boolean",
           "default": true,
@@ -141,6 +132,15 @@
           "default": true,
           "scope": "window",
           "markdownDescription": "Enable oxfmt (formatter). Falls back to `oxc.enable` if not set."
+        },
+        "oxc.enable": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null,
+          "scope": "window",
+          "markdownDescription": "This is a master toggle for both `oxc.enable.oxlint` and `oxc.enable.oxfmt`."
         },
         "oxc.requireConfig": {
           "scope": "resource",


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc-vscode/issues/204

Somehow the errors are not appearing with this fix:
```
filterEnabledExtensions: extension 'GitHub.copilot-chat' is disabled
Ignoring oxc.enable.oxlint as oxc.enable is null
Ignoring oxc.enable.oxfmt as oxc.enable is null
Ignoring oxc.enable.oxlint as oxc.enable is null
Ignoring oxc.enable.oxfmt as oxc.enable is null
```