### PR TITLE
fix: pass esm loader as file url for yarn pnp

### DIFF
--- a/client/tools/lsp_helper.ts
+++ b/client/tools/lsp_helper.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import { LogOutputChannel, window } from "vscode";
 import { Executable, MessageType, ShowMessageParams } from "vscode-languageclient/node";
 import type { BinarySearchResult } from "../findBinary";
@@ -55,7 +56,7 @@ export async function runExecutable(
   if (isNode && binary.yarnPnpLoaderPath) {
     pnpArgs.push("--require", binary.yarnPnpLoaderPath);
     const esmLoaderPath = path.join(path.dirname(binary.yarnPnpLoaderPath), ".pnp.loader.mjs");
-    pnpArgs.push("--loader", esmLoaderPath);
+    pnpArgs.push("--loader", pathToFileURL(esmLoaderPath).href);
   }
 
   return isNode || useExecPath

--- a/tests/unit/lsp_helper.spec.ts
+++ b/tests/unit/lsp_helper.spec.ts
@@ -1,6 +1,7 @@
 import { strictEqual } from "assert";
 import { runExecutable } from "../../client/tools/lsp_helper";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 
 suite("runExecutable", () => {
   const originalPlatform = process.platform;
@@ -147,11 +148,9 @@ suite("runExecutable", () => {
     strictEqual(result.args?.includes("--require"), true);
     strictEqual(result.args?.includes("/path/to/.pnp.cjs"), true, JSON.stringify(result.args));
     strictEqual(result.args?.includes("--loader"), true);
-    // will be converted to Windows path with backslashes
-    strictEqual(
-      result.args?.includes(`${path.sep}path${path.sep}to${path.sep}.pnp.loader.mjs`),
-      true,
-      JSON.stringify(result.args),
-    );
+    const expectedEsmLoaderPath = pathToFileURL(
+      `${path.sep}path${path.sep}to${path.sep}.pnp.loader.mjs`,
+    ).href;
+    strictEqual(result.args?.includes(expectedEsmLoaderPath), true, JSON.stringify(result.args));
   });
 });


### PR DESCRIPTION
## Problem
Getting the following error on Windows under Yarn PnP:

```
ERROR  Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only file and data URLs are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

ESM loader expects `file:` protocol, but on Windows it receives `{driveLetter}:` as protocol and fails with above error.

## Fix
Use `pathToFileURL` to convert file to proper URL format.