### PR TITLE
chore: ignore `.vscode` folder when formatting

### DIFF
--- a/oxfmt.config.json
+++ b/oxfmt.config.json
@@ -1,4 +1,4 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": ["fixtures/**"]
+  "ignorePatterns": ["fixtures/**", ".vscode/**"]
 }


### PR DESCRIPTION
Somehow it is failing in CI for other PRs.
See https://github.com/oxc-project/oxc-vscode/actions/runs/27105996655/job/79995135470?pr=287
