### PR TITLE
fix: resolve .cmd binary path and node resolution on Windows

### DIFF
--- a/client/findBinary.ts
+++ b/client/findBinary.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import{ spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import * as path from "node:path";
@@ -44,7 +44,11 @@ async function searchNodeModulesDefaultBinPath(
 ): Promise<BinarySearchResult | undefined> {
   const candidates = folders.flatMap((folder) => {
     const basePath = path.join(folder, ".bin", binaryName);
-    return process.platform === "win32" ? [basePath, `${basePath}.exe`] : [basePath];
+    // On Windows, prioritize .cmd (npm/pnpm/yarn bin scripts), then .exe (bun/global installs),
+    // then the bare name as fallback.
+    return process.platform === "win32"
+      ? [`${basePath}.cmd`, `${basePath}.exe`, basePath]
+      : [basePath];
   });
 
   const exists = await Promise.all(
@@ -237,14 +241,16 @@ export async function searchEnvPath(
   }
 
   // generate candidate paths by joining each PATH entry with the binary name
-  // on Windows, also consider the .exe extension
+  // on Windows, also consider .cmd and .exe extensions
   const candidates = envPath.split(path.delimiter).flatMap((folder) => {
     // filter out empty entries which can occur if PATH starts or ends with a delimiter
     if (!folder) {
       return [];
     }
     const basePath = path.join(folder, defaultBinaryName);
-    return process.platform === "win32" ? [basePath, `${basePath}.exe`] : [basePath];
+    return process.platform === "win32"
+      ? [`${basePath}.cmd`, `${basePath}.exe`, basePath]
+      : [basePath];
   });
 
   const binary = await Promise.all(

--- a/client/tools/lsp_helper.ts
+++ b/client/tools/lsp_helper.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import { LogOutputChannel, window } from "vscode";
@@ -59,6 +60,26 @@ export async function runExecutable(
     pnpArgs.push("--loader", pathToFileURL(esmLoaderPath).href);
   }
 
+  // On Windows, .cmd files (npm/pnpm/yarn bin wrappers) are shell scripts that
+  // invoke `node <actual-script>`. When VS Code is launched from the GUI, node
+  // managers like fnm/nvm/Volta are not in PATH, so the shell execution fails.
+  // Instead, we parse the .cmd file to extract the actual target script, then
+  // use VS Code's own embedded Node.js (process.execPath) to run it directly.
+  // This approach works on every Windows machine regardless of node manager.
+  if (isWindows && binary.path.toLowerCase().endsWith(".cmd")) {
+    const target = resolveCmdTarget(binary.path);
+    if (target) {
+      return {
+        command: process.execPath,
+        args: [target, "--lsp"],
+        options: {
+          env: { ...serverEnv, ELECTRON_RUN_AS_NODE: "1" },
+        },
+      };
+    }
+    // If parsing fails, fall through to shell execution below
+  }
+
   return isNode || useExecPath
     ? {
         command: nodeCommand,
@@ -81,6 +102,33 @@ export async function runExecutable(
           env: serverEnv,
         },
       };
+}
+
+/**
+ * Parse a Windows .cmd wrapper script (from node_modules/.bin/) to extract
+ * the actual target script path. .cmd files follow a standard format generated
+ * by npm/pnpm/yarn:
+ *
+ *   node  "%~dp0\..\<pkg>\bin\<script>" %*
+ *
+ * "%~dp0" resolves to the directory of the .cmd file itself.
+ */
+function resolveCmdTarget(cmdPath: string): string | undefined {
+  try {
+    const content = readFileSync(cmdPath, "utf8");
+    const cmdDir = path.dirname(cmdPath);
+
+    // Find the execution line: node followed by a quoted path
+    // Handles both: node  "%~dp0\..\foo" %*  and  node  "..\foo" %*
+    const match = content.match(/node\s+"([^"]+)"/);
+    if (!match) return undefined;
+
+    // Replace %~dp0 with the actual directory of the .cmd file
+    const resolved = match[1].replace(/%~dp0/g, cmdDir);
+    return path.resolve(resolved);
+  } catch {
+    return undefined;
+  }
 }
 
 export function onClientNotification(params: ShowMessageParams, outputChannel: LogOutputChannel) {


### PR DESCRIPTION
## Problem

On Windows, the extension fails to start oxlint/oxfmt language servers when VS Code is launched from the GUI (Start Menu / taskbar) while using node version managers like **fnm**, **nvm-windows**, or **Volta**.

Error output:
```
'node' is not recognized as an internal or external command, operable program or batch file.

Server process exited with code 1
```

## Root Cause

Two cascading issues:

### 1. Binary selection: Bash script picked instead of `.cmd`

`node_modules/.bin/` on Windows contains three entry types:

| File | Type | Works on Windows? |
|------|------|-------------------|
| `oxfmt` (no extension) | Bash script (`#!/usr/bin/env node`) | ❌ |
| `oxfmt.cmd` | Windows batch wrapper | ✅ |
| `oxfmt.ps1` | PowerShell wrapper | ⚠️ partial |

`searchNodeModulesDefaultBinPath()` previously searched `[bare name, .exe]` — missing `.cmd`. It returned the extensionless Bash script, which Windows can't execute natively.

### 2. `node` not in PATH (GUI-launched VS Code)

Node version managers (fnm/nvm/Volta) inject `node` into PATH only in terminal sessions. When VS Code is launched from the Start Menu, `process.env.PATH` does not contain the node installation directory.

Even after switching to `.cmd` (issue 1 fixed), the `.cmd` wrapper internally calls:
```cmd
node  "%~dp0\..\oxfmt\bin\oxfmt" %*
```
…which still fails because `node` is not on PATH.

## Solution

Two changes:

### `client/findBinary.ts` — Prioritize `.cmd`

Changed search order from `[bare, .exe]` → `[.cmd, .exe, bare]`:

```ts
// Before
return process.platform === "win32" ? [basePath, `${basePath}.exe`] : [basePath];

// After
return process.platform === "win32"
  ? [`${basePath}.cmd`, `${basePath}.exe`, basePath]
  : [basePath];
```

Applied to both `searchNodeModulesDefaultBinPath()` and `searchEnvPath()`.

### `client/tools/lsp_helper.ts` — Use VS Code's embedded Node.js

Added `resolveCmdTarget()` that parses the `.cmd` wrapper to extract the actual target script path, then executes it directly with `process.execPath` (VS Code's own Electron Node.js):

```ts
if (isWindows && binary.path.toLowerCase().endsWith(".cmd")) {
  const target = resolveCmdTarget(binary.path);
  if (target) {
    return {
      command: process.execPath,       // VS Code's built-in Node
      args: [target, "--lsp"],
      options: { env: { ...serverEnv, ELECTRON_RUN_AS_NODE: "1" } },
    };
  }
  // fallback: shell execution
}
```

This approach is **universal** — it doesn't hardcode any path, doesn't guess where fnm/nvm/Volta is installed, and works regardless of the node manager.

## Verification

- ✅ Tested on Windows 10 + fnm + pnpm, VS Code launched from Start Menu
- ✅ `oxfmt.cmd` is properly resolved and server starts successfully
- ✅ Falls back gracefully to shell execution if `.cmd` parsing fails
- ✅ No changes to macOS/Linux behavior