### PR TITLE
fix: prevent possible hang on interactive POSIX shell when getting shell env

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,6 @@ Each rule name maps to an object with the following optional properties:
 
 <p align="center">
   <a href="https://github.com/sponsors/Boshen">
-    <!-- <img src="https://raw.githubusercontent.com/Boshen/sponsors/main/sponsors.svg" alt="Our sponsors" /> -->
+    <img src="https://raw.githubusercontent.com/Boshen/sponsors/main/sponsors.svg" alt="Our sponsors" />
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -143,6 +143,6 @@ Each rule name maps to an object with the following optional properties:
 
 <p align="center">
   <a href="https://github.com/sponsors/Boshen">
-    <img src="https://raw.githubusercontent.com/Boshen/sponsors/main/sponsors.svg" alt="Our sponsors" />
+    <!-- <img src="https://raw.githubusercontent.com/Boshen/sponsors/main/sponsors.svg" alt="Our sponsors" /> -->
   </a>
 </p>

--- a/client/getShellEnv.ts
+++ b/client/getShellEnv.ts
@@ -34,23 +34,57 @@ async function getInteractiveShellEnv(): Promise<Record<string, string | undefin
   const shell = process.env.SHELL ?? "/bin/bash";
 
   try {
+    const TIMEOUT_MS = 5000;
+
     // POSIX shells
     // Run the shell as a login shell to get the environment variables. The `-i` flag is for interactive shell, which is needed to load the shell configuration files.
     // The `-l` flag is for login shell, which is needed to load the environment variables defined in the shell configuration files.
-    const { stdout } = await execFileAsync(
+    const execPromise = execFileAsync(
       shell,
       ["-ilc", 'echo -n "_ENV_DELIMITER_"; command env; echo -n "_ENV_DELIMITER_"; exit'],
       {
         env: {
           HOME: process.env.HOME,
           // indicates that this shell is only launched to read the environment - tools like inshellisense
-          // check for this to prevent re-executing the shell 
+          // check for this to prevent breaking interactive shell output
           // https://code.visualstudio.com/docs/configure/command-line#_how-do-i-detect-when-a-shell-was-launched-by-vs-code
           VSCODE_RESOLVING_ENVIRONMENT: "1",
         },
-        timeout: 5000,
+        timeout: TIMEOUT_MS,
       },
     );
+
+    const child = execPromise.child;
+    let exited = false;
+
+    child.once("exit", () => {
+      exited = true;
+    });
+
+    let timeoutId: NodeJS.Timeout | undefined;
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        if (!exited && child.pid) {
+          try {
+            // Kill the whole process group so grandchildren cannot keep stdio open.
+            process.kill(-child.pid, "SIGKILL");
+          } catch {}
+        }
+        reject(`Failed to get shell environment variables within ${TIMEOUT_MS}ms.`);
+      }, TIMEOUT_MS);
+    });
+
+    // Avoid an unhandled rejection if execPromise settles after the timeout wins.
+    execPromise.catch(() => {});
+
+    // In some cases the execFile promise may not resolve or reject, e.g if the shell is misconfigured or requires user input.
+    // To avoid waiting indefinitely, we use Promise.race with the same timeout as the shell command.
+    const { stdout } = await Promise.race([execPromise, timeoutPromise]);
+
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
 
     const envsOutput = stdout.split("_ENV_DELIMITER_")[1] ?? "";
     if (!envsOutput) {

--- a/client/getShellEnv.ts
+++ b/client/getShellEnv.ts
@@ -43,6 +43,10 @@ async function getInteractiveShellEnv(): Promise<Record<string, string | undefin
       {
         env: {
           HOME: process.env.HOME,
+          // indicates that this shell is only launched to read the environment - tools like inshellisense
+          // check for this to prevent re-executing the shell 
+          // https://code.visualstudio.com/docs/configure/command-line#_how-do-i-detect-when-a-shell-was-launched-by-vs-code
+          VSCODE_RESOLVING_ENVIRONMENT: "1",
         },
         timeout: 5000,
       },

--- a/tests/unit/getShellEnv.spec.ts
+++ b/tests/unit/getShellEnv.spec.ts
@@ -15,11 +15,7 @@ async function loadFreshGetShellEnvModule(): Promise<GetShellEnvModule> {
   return module;
 }
 
-function createMockShellScript(
-  dir: string,
-  name: string,
-  scriptBody: string,
-): string {
+function createMockShellScript(dir: string, name: string, scriptBody: string): string {
   const filePath = path.join(dir, name);
   writeFileSync(filePath, `#!/bin/sh\n${scriptBody}\n`, { mode: 0o755 });
   return filePath;
@@ -77,11 +73,7 @@ suite("getShellEnv", () => {
     }
 
     process.env.GET_SHELL_ENV_TEST_KEY = "fallback-works";
-    const shellPath = createMockShellScript(
-      tempDir,
-      "mock-shell-empty.sh",
-      "# no output",
-    );
+    const shellPath = createMockShellScript(tempDir, "mock-shell-empty.sh", "# no output");
 
     process.env.SHELL = shellPath;
 

--- a/tests/unit/getShellEnv.spec.ts
+++ b/tests/unit/getShellEnv.spec.ts
@@ -1,0 +1,125 @@
+import { strictEqual } from "assert";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+type GetShellEnvModule = {
+  getShellEnv: () => Promise<Record<string, string | undefined>>;
+};
+
+async function loadFreshGetShellEnvModule(): Promise<GetShellEnvModule> {
+  const timestamp = Date.now();
+  // append a query parameter to force a fresh import of the module to reset the cachedEnv variable
+  const module = await import(`../../client/getShellEnv.ts?ts=${timestamp}`);
+
+  return module;
+}
+
+function createMockShellScript(
+  dir: string,
+  name: string,
+  scriptBody: string,
+): string {
+  const filePath = path.join(dir, name);
+  writeFileSync(filePath, `#!/bin/sh\n${scriptBody}\n`, { mode: 0o755 });
+  return filePath;
+}
+
+suite("getShellEnv", () => {
+  let tempDir: string;
+  const originalPlatform = process.platform;
+  const originalEnv = process.env;
+
+  setup(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "get-shell-env-test-"));
+  });
+
+  teardown(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    process.env = originalEnv;
+  });
+
+  test("returns process.env directly on win32", async () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    process.env.GET_SHELL_ENV_TEST_KEY = "windows-fast-path";
+    process.env.SHELL = path.join(tempDir, "does-not-matter-on-win32");
+
+    const { getShellEnv } = await loadFreshGetShellEnvModule();
+    const env = await getShellEnv();
+
+    strictEqual(env.GET_SHELL_ENV_TEST_KEY, "windows-fast-path");
+  });
+
+  test("parses shell output into env object", async function () {
+    if (process.platform === "win32") {
+      this.skip();
+    }
+
+    const shellPath = createMockShellScript(
+      tempDir,
+      "mock-shell-success.sh",
+      'printf "_ENV_DELIMITER_PATH=/mock/bin\\nFOO=bar\\nEQ=a=b\\n_ENV_DELIMITER_"',
+    );
+
+    process.env.SHELL = shellPath;
+
+    const { getShellEnv } = await loadFreshGetShellEnvModule();
+    const env = await getShellEnv();
+
+    strictEqual(env.PATH, "/mock/bin");
+    strictEqual(env.FOO, "bar");
+    strictEqual(env.EQ, "a=b");
+  });
+
+  test("falls back to process.env when shell output is empty", async function () {
+    if (process.platform === "win32") {
+      this.skip();
+    }
+
+    process.env.GET_SHELL_ENV_TEST_KEY = "fallback-works";
+    const shellPath = createMockShellScript(
+      tempDir,
+      "mock-shell-empty.sh",
+      "# no output",
+    );
+
+    process.env.SHELL = shellPath;
+
+    const { getShellEnv } = await loadFreshGetShellEnvModule();
+    const env = await getShellEnv();
+
+    strictEqual(env.GET_SHELL_ENV_TEST_KEY, "fallback-works");
+  });
+
+  test("falls back to process.env when shell executable is invalid", async () => {
+    process.env.GET_SHELL_ENV_TEST_KEY = "reject-fallback";
+    process.env.SHELL = path.join(tempDir, "does-not-exist-shell");
+
+    const { getShellEnv } = await loadFreshGetShellEnvModule();
+    const env = await getShellEnv();
+
+    strictEqual(env.GET_SHELL_ENV_TEST_KEY, "reject-fallback");
+  });
+
+  test("falls back to process.env after timeout", async function () {
+    if (process.platform === "win32") {
+      this.skip();
+    }
+
+    process.env.GET_SHELL_ENV_TEST_KEY = "timeout-fallback";
+
+    const shellPath = createMockShellScript(
+      tempDir,
+      "mock-shell-timeout.sh",
+      'sleep 6; printf "_ENV_DELIMITER_TIMEOUT_SHOULD_NOT_APPEAR=1\\n_ENV_DELIMITER_"',
+    );
+
+    process.env.SHELL = shellPath;
+
+    const { getShellEnv } = await loadFreshGetShellEnvModule();
+    const env = await getShellEnv();
+
+    strictEqual(env.GET_SHELL_ENV_TEST_KEY, "timeout-fallback");
+    strictEqual(env.TIMEOUT_SHOULD_NOT_APPEAR, undefined);
+  });
+});


### PR DESCRIPTION
- adds a fallback timeout to prevent `getShellEnv` hanging infinitely when the shell has no output
- adds the `VSCODE_RESOLVING_ENVIRONMENT` which may be used by some shell tools to treat an interactive shell as only for probing the env

I ran into an issue where the extension would start OK when launching vscode, but any subsequent window reload / extension restart / extension host restart would cause it to hang indefinitely on `[info] Searching for oxlint binary.`.

I am using zsh with [inshellisense](https://github.com/microsoft/inshellisense), which sources an init script in `.zshrc`, which re-executes zsh with its own shell. 
The `getInteractiveShellEnv` script runs as interactive, so the env contents are never echoed, the shell just clears and stout never returns anything.

I'm not sure how widely `VSCODE_RESOLVING_ENVIRONMENT` is used in other shell hooks, but I can confirm this fixes the issue when using inshellisense.

In order to fix the more general cases of shell (mis)configurations, I added a separate node timeout that kills the process and rejects so that the outer catch can return the process.env fallback.

possible fix for https://github.com/oxc-project/oxc-vscode/issues/185