### PR TITLE
docs: document oxlint and oxfmt prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Any of the below options can be used to install the extension.
 - Install through the VS Code extensions marketplace by searching for `Oxc`. Verify the identifier is `oxc.oxc-vscode`.
 - From within VS Code, open the Quick Open (Ctrl+P or Cmd+P on macOS) and execute `ext install oxc.oxc-vscode`.
 
+The extension does not bundle the Oxc tools. For the recommended setup, install the tool you want to use locally in your project: `oxlint` for linting and `oxfmt` for formatting. If you install a tool while VS Code is already open and it is not detected, run **Developer: Reload Window**, then hover over the `oxc` status item or check the corresponding `Oxc (Lint)` or `Oxc (Fmt)` output channel.
+
+See the official [Oxlint editor setup](https://oxc.rs/docs/guide/usage/linter/editors.html) and [Oxfmt editor setup](https://oxc.rs/docs/guide/usage/formatter/editors.html) guides for installation details.
+
 ## Oxlint
 
 This is the linter for Oxc. The currently supported features are listed below.


### PR DESCRIPTION
## Summary

- document that the extension relies on separately installed `oxlint` and `oxfmt` binaries
- recommend project-local installation for the tool a project uses
- add reload and diagnostic steps for binaries that are not detected, including the `oxc` status item and the `Oxc (Lint)` / `Oxc (Fmt)` output channels
- link to the official Oxlint and Oxfmt editor setup guides

This addresses the documentation gap reported in #311 without changing formatter language support or binary discovery behavior.

Refs #311

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm run docs:update`
- `pnpm run lint`
- `pnpm run fmt:check`
- `pnpm run compile`
- `git diff --check origin/main...HEAD`
- verified that both linked official setup guides return HTTP 200

## AI usage

This change was prepared with assistance from OpenAI Codex. I reviewed and understand the change and accept responsibility for it.
