### PR TITLE
fix: `oxc.requireConfig` watch for `oxlint.config.mts` too

### DIFF
--- a/client/tools/linter.ts
+++ b/client/tools/linter.ts
@@ -36,7 +36,7 @@ const enum LspCommands {
   FixAll = "oxc.fixAll",
 }
 
-const oxlintConfigDefaultFilePattern = `**/{.oxlintrc.json,.oxlintrc.jsonc,oxlint.config.ts}`;
+const oxlintConfigDefaultFilePattern = `**/{.oxlintrc.json,.oxlintrc.jsonc,oxlint.config.ts,oxlint.config.mts}`;
 
 export default class LinterTool implements ToolInterface {
   // Global flag to check if the user allows us to start the server.


### PR DESCRIPTION
upstream PR https://github.com/oxc-project/oxc/pull/24357