### PR TITLE
docs: use png for sponsor image

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ Each rule name maps to an object with the following optional properties:
 
 <p align="center">
   <a href="https://oxc.rs/sponsor">
-    <img src="https://raw.githubusercontent.com/oxc-project/sponsors/main/sponsors.svg" alt="Our sponsors" />
+    <img src="https://raw.githubusercontent.com/oxc-project/sponsors/main/sponsors.png" alt="Our sponsors" />
   </a>
 </p>


### PR DESCRIPTION
Got the following error, with PNG it works:

```
~/dev/oxc-vscode$ pnpm build
$ pnpm run compile && pnpm run package
$ rolldown -c rolldown.config.ts
<DIR>/main.js.map  asset │ size: 1,702.52 kB                                                                                                                                                                                          
<DIR>/main.js      chunk │ size:   465.95 kB                                                                                                                                                                                          
                                                                                                                                                                                                                                      
✔ rolldown v1.2.0 Finished in 133.24 ms                                                                                                                                                                                              
$ vsce package --no-dependencies -o oxc_language_server.vsix
 ERROR  SVGs are restricted in README.md; please use other file image formats, such as PNG: https://raw.githubusercontent.com/oxc-project/sponsors/main/sponsors.svg
```