### PR TITLE
fix: schema for `oxc.lint.customization` `warn` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Following configurations are supported via `settings.json` and can be changed fo
 Each rule name maps to an object with the following optional properties:
 
 - `autofix`: `true` \| `false` — Whether autofix should be disabled for this rule.
-- `severity`: `"error"` \| `"warning"` \| `"info"` \| `"hint"` \| `"off"` — Diagnostic severity override for this rule.
+- `severity`: `"error"` \| `"warn"` \| `"info"` \| `"hint"` \| `"off"` — Diagnostic severity override for this rule.
 
 **Example:**
 

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
                 "type": "string",
                 "enum": [
                   "error",
-                  "warning",
+                  "warn",
                   "info",
                   "hint",
                   "off"


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc-vscode/issues/352