### PR TITLE
fix: register restart commands for both lint & fmt on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Any of the below options can be used to install the extension.
 - Install through the VS Code extensions marketplace by searching for `Oxc`. Verify the identifier is `oxc.oxc-vscode`.
 - From within VS Code, open the Quick Open (Ctrl+P or Cmd+P on macOS) and execute `ext install oxc.oxc-vscode`.
 
-The extension does not bundle the Oxc tools. For the recommended setup, install the tool you want to use locally in your project: `oxlint` for linting and `oxfmt` for formatting. If you install a tool while VS Code is already open and it is not detected, run **Developer: Reload Window**, then hover over the `oxc` status item or check the corresponding `Oxc (Lint)` or `Oxc (Fmt)` output channel.
+The extension does not bundle the Oxc tools. For the recommended setup, install the tool you want to use locally in your project: `oxlint` for linting and `oxfmt` for formatting. If you install a tool while VS Code is already open and it is not detected, run the **Oxc: Restart oxlint Server** and/or **Oxc: Restart oxfmt Server** commands, then hover over the `oxc` status item or check the corresponding `Oxc (Lint)` or `Oxc (Fmt)` output channel.
 
 See the official [Oxlint editor setup](https://oxc.rs/docs/guide/usage/linter/editors.html) and [Oxfmt editor setup](https://oxc.rs/docs/guide/usage/formatter/editors.html) guides for installation details.
 

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -133,4 +133,5 @@ export async function activate(context: ExtensionContext) {
 
 export async function deactivate(): Promise<void> {
   await Promise.all(tools.map((tool) => tool.deactivate()));
+  tools.length = 0
 }

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -10,13 +10,6 @@ import ToolInterface from "./tools/ToolInterface";
 const outputChannelName = "Oxc";
 const tools: ToolInterface[] = [];
 
-if (process.env.SKIP_LINTER_TEST !== "true") {
-  tools.push(new Linter());
-}
-if (process.env.SKIP_FORMATTER_TEST !== "true") {
-  tools.push(new Formatter());
-}
-
 export async function activate(context: ExtensionContext) {
   const configService = new ConfigService();
 
@@ -69,6 +62,14 @@ export async function activate(context: ExtensionContext) {
     statusBarItemHandler,
   );
 
+  // Instantiate tools after base commands are registered to maintain command registration order
+  if (process.env.SKIP_LINTER_TEST !== "true") {
+    tools.push(new Linter());
+  }
+  if (process.env.SKIP_FORMATTER_TEST !== "true") {
+    tools.push(new Formatter());
+  }
+
   const restartTool = async (tool: ToolInterface, outputChannel: LogOutputChannel) => {
     try {
       await tool.restart(outputChannel, configService, statusBarItemHandler);
@@ -119,6 +120,8 @@ export async function activate(context: ExtensionContext) {
     tools.map((tool): Promise<void> => {
       const channel = tool instanceof Linter ? outputChannelLint : outputChannelFormat;
       const binaryPath = binaryPaths[tools.indexOf(tool)];
+
+      context.subscriptions.push(tool)
 
       return tool.activate(channel, configService, statusBarItemHandler, binaryPath);
     }),

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -64,15 +64,19 @@ export async function activate(context: ExtensionContext) {
 
   // Instantiate tools after base commands are registered to maintain command registration order
   if (process.env.SKIP_LINTER_TEST !== "true") {
-    tools.push(new Linter());
+    const linter = new Linter(outputChannelLint, configService, statusBarItemHandler);
+    tools.push(linter);
+    context.subscriptions.push(linter);
   }
   if (process.env.SKIP_FORMATTER_TEST !== "true") {
-    tools.push(new Formatter());
+    const formatter = new Formatter(outputChannelFormat, configService, statusBarItemHandler);
+    tools.push(formatter);
+    context.subscriptions.push(formatter);
   }
 
   const restartTool = async (tool: ToolInterface, outputChannel: LogOutputChannel) => {
     try {
-      await tool.restart(outputChannel, configService, statusBarItemHandler);
+      await tool.restart();
     } catch (e) {
       outputChannel.error(`Failed to restart tool, error: ${e instanceof Error ? e.message : String(e)}.
       Try to restart the editor manually.
@@ -81,9 +85,7 @@ export async function activate(context: ExtensionContext) {
   };
 
   configService.onConfigChange = async function onConfigChange(event) {
-    await Promise.all(
-      tools.map((tool) => tool.onConfigChange(event, configService, statusBarItemHandler)),
-    );
+    await Promise.all(tools.map((tool) => tool.onConfigChange(event)));
 
     if (configService.vsCodeConfig.effectsOxlintConnection(event)) {
       outputChannelLint.info("oxlint connection changed, restarting oxlint tool.");
@@ -107,23 +109,12 @@ export async function activate(context: ExtensionContext) {
   outputChannelFormat.info("Searching for oxfmt binary.");
   outputChannelLint.info("Searching for oxlint binary.");
 
-  const binaryPaths = await Promise.all(
-    tools.map((tool) =>
-      tool.getBinary(
-        tool instanceof Linter ? outputChannelLint : outputChannelFormat,
-        configService,
-      ),
-    ),
-  );
+  const binaryPaths = await Promise.all(tools.map((tool) => tool.getBinary()));
 
   await Promise.all(
     tools.map((tool): Promise<void> => {
-      const channel = tool instanceof Linter ? outputChannelLint : outputChannelFormat;
       const binaryPath = binaryPaths[tools.indexOf(tool)];
-
-      context.subscriptions.push(tool);
-
-      return tool.activate(channel, configService, statusBarItemHandler, binaryPath);
+      return tool.activate(binaryPath);
     }),
   );
 
@@ -133,5 +124,5 @@ export async function activate(context: ExtensionContext) {
 
 export async function deactivate(): Promise<void> {
   await Promise.all(tools.map((tool) => tool.deactivate()));
-  tools.length = 0
+  tools.length = 0;
 }

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -121,7 +121,7 @@ export async function activate(context: ExtensionContext) {
       const channel = tool instanceof Linter ? outputChannelLint : outputChannelFormat;
       const binaryPath = binaryPaths[tools.indexOf(tool)];
 
-      context.subscriptions.push(tool)
+      context.subscriptions.push(tool);
 
       return tool.activate(channel, configService, statusBarItemHandler, binaryPath);
     }),

--- a/client/tools/ToolInterface.ts
+++ b/client/tools/ToolInterface.ts
@@ -31,6 +31,12 @@ export default interface ToolInterface {
   deactivate(): Promise<void>;
 
   /**
+   * Dispose of commands registered at construction.
+   * Should be called when the tool is permanently disposed (e.g., extension deactivation).
+   */
+  dispose(): void;
+
+  /**
    * Restarts the tool, cleaning up resources and reinitializing with the current configuration.
    */
   restart(

--- a/client/tools/ToolInterface.ts
+++ b/client/tools/ToolInterface.ts
@@ -1,6 +1,4 @@
-import { ConfigurationChangeEvent, LogOutputChannel } from "vscode";
-import { ConfigService } from "../ConfigService";
-import StatusBarItemHandler from "../StatusBarItemHandler";
+import { ConfigurationChangeEvent } from "vscode";
 import type { BinarySearchResult } from "../findBinary";
 
 export default interface ToolInterface {
@@ -11,19 +9,11 @@ export default interface ToolInterface {
   /**
    * Gets the path to the tool's language server binary (if applicable).
    */
-  getBinary(
-    outputChannel: LogOutputChannel,
-    configService: ConfigService,
-  ): Promise<BinarySearchResult | undefined>;
+  getBinary(): Promise<BinarySearchResult | undefined>;
   /**
    * Activates the tool and initializes any necessary resources.
    */
-  activate(
-    outputChannel: LogOutputChannel,
-    configService: ConfigService,
-    statusBarItemHandler: StatusBarItemHandler,
-    binary?: BinarySearchResult,
-  ): Promise<void>;
+  activate(binary?: BinarySearchResult): Promise<void>;
 
   /**
    * Deactivates the tool and cleans up any resources.
@@ -39,18 +29,10 @@ export default interface ToolInterface {
   /**
    * Restarts the tool, cleaning up resources and reinitializing with the current configuration.
    */
-  restart(
-    outputChannel: LogOutputChannel,
-    configService: ConfigService,
-    statusBarItemHandler: StatusBarItemHandler,
-  ): Promise<void>;
+  restart(): Promise<void>;
 
   /**
    * Handles configuration changes.
    */
-  onConfigChange(
-    event: ConfigurationChangeEvent,
-    configService: ConfigService,
-    statusBarItemHandler: StatusBarItemHandler,
-  ): Promise<void>;
+  onConfigChange(event: ConfigurationChangeEvent): Promise<void>;
 }

--- a/client/tools/formatter.ts
+++ b/client/tools/formatter.ts
@@ -296,7 +296,10 @@ export default class FormatterTool implements ToolInterface {
       {
         provideCodeActions: (doc) => {
           if (
-            this.configService?.vsCodeConfig.enableOxfmt === false ||
+            !this.configService ||
+            !this.client ||
+            !this.client.isRunning() ||
+            this.configService.vsCodeConfig.enableOxfmt === false ||
             workspace.getConfiguration("editor", doc).get("defaultFormatter") !== "oxc.oxc-vscode"
           ) {
             return [];

--- a/client/tools/formatter.ts
+++ b/client/tools/formatter.ts
@@ -264,21 +264,20 @@ export default class FormatterTool implements ToolInterface {
 
   private disposeResources: (() => Promise<void>) | undefined;
 
-  // Dependencies needed by commands
-  private outputChannel: LogOutputChannel | undefined;
-  private configService: ConfigService | undefined;
-  private statusBarItemHandler: StatusBarItemHandler | undefined;
-
   // Command and provider disposables (registered once at construction)
   private readonly restartCommand: { dispose: () => void };
   private readonly toggleEnableCommand: { dispose: () => void };
   private readonly formatActionProvider: { dispose: () => void };
 
-  constructor() {
+  constructor(
+    private readonly outputChannel: LogOutputChannel,
+    private readonly configService: ConfigService,
+    private readonly statusBarItemHandler: StatusBarItemHandler,
+  ) {
     // Register commands once at construction
     this.restartCommand = commands.registerCommand(OxcCommands.RestartServerFmt, async () => {
       if (this.outputChannel && this.configService && this.statusBarItemHandler) {
-        await this.restart(this.outputChannel, this.configService, this.statusBarItemHandler);
+        await this.restart();
       }
     });
 
@@ -317,48 +316,37 @@ export default class FormatterTool implements ToolInterface {
     return this.client?.initializeResult?.serverInfo?.version;
   }
 
-  async getBinary(
-    outputChannel: LogOutputChannel,
-    configService: ConfigService,
-  ): Promise<BinarySearchResult | undefined> {
+  async getBinary(): Promise<BinarySearchResult | undefined> {
     if (process.env.SERVER_PATH_DEV) {
       return { path: process.env.SERVER_PATH_DEV, loader: "native" };
     }
-    const bin = await configService.getOxfmtServerBinPath();
+    const bin = await this.configService.getOxfmtServerBinPath();
     if (bin) {
       try {
         await fsPromises.access(bin.path);
         return bin;
       } catch (e) {
-        outputChannel.error(`Invalid bin path: ${bin.path}`, e);
+        this.outputChannel.error(`Invalid bin path: ${bin.path}`, e);
       }
     }
   }
 
-  async activate(
-    outputChannel: LogOutputChannel,
-    configService: ConfigService,
-    statusBarItemHandler: StatusBarItemHandler,
-    binary?: BinarySearchResult,
-  ) {
-    // Store dependencies for command handlers
-    this.outputChannel = outputChannel;
-    this.configService = configService;
-    this.statusBarItemHandler = statusBarItemHandler;
-
+  async activate(binary?: BinarySearchResult) {
     // No valid binary found for the formatter.
     if (!binary) {
-      statusBarItemHandler.updateTool("formatter", false, "No valid oxfmt binary found.");
-      outputChannel.appendLine("No valid oxfmt binary found. Formatter will not be activated.");
+      this.statusBarItemHandler.updateTool("formatter", false, "No valid oxfmt binary found.");
+      this.outputChannel.appendLine(
+        "No valid oxfmt binary found. Formatter will not be activated.",
+      );
       return Promise.resolve();
     }
 
-    outputChannel.info(`Using server binary at: ${binary?.path}`);
+    this.outputChannel.info(`Using server binary at: ${binary?.path}`);
 
     const run: Executable = await runExecutable(
       binary,
-      configService.vsCodeConfig.useExecPath,
-      configService.vsCodeConfig.nodePath,
+      this.configService.vsCodeConfig.useExecPath,
+      this.configService.vsCodeConfig.nodePath,
     );
 
     const serverOptions: ServerOptions = {
@@ -372,9 +360,9 @@ export default class FormatterTool implements ToolInterface {
     const clientOptions: LanguageClientOptions = {
       // Register the server for plain text documents
       documentSelector: this.documentSelectors,
-      initializationOptions: configService.formatterServerConfig,
-      outputChannel,
-      traceOutputChannel: outputChannel,
+      initializationOptions: this.configService.formatterServerConfig,
+      outputChannel: this.outputChannel,
+      traceOutputChannel: this.outputChannel,
       middleware: {
         workspace: {
           configuration: (params: ConfigurationParams) => {
@@ -387,7 +375,8 @@ export default class FormatterTool implements ToolInterface {
               }
 
               return (
-                configService.getWorkspaceConfig(Uri.parse(item.scopeUri))?.toOxfmtConfig() ?? null
+                this.configService.getWorkspaceConfig(Uri.parse(item.scopeUri))?.toOxfmtConfig() ??
+                null
               );
             });
           },
@@ -401,7 +390,7 @@ export default class FormatterTool implements ToolInterface {
     const onNotificationDispose = this.client.onNotification(
       ShowMessageNotification.type,
       (params) => {
-        onClientNotification(params, outputChannel);
+        onClientNotification(params, this.outputChannel);
       },
     );
 
@@ -410,11 +399,11 @@ export default class FormatterTool implements ToolInterface {
       onNotificationDispose.dispose();
     };
 
-    if (configService.vsCodeConfig.enableOxfmt) {
+    if (this.configService.vsCodeConfig.enableOxfmt) {
       await this.client.start();
     }
 
-    this.updateStatusBar(statusBarItemHandler, configService);
+    this.updateStatusBar();
   }
 
   async deactivate(): Promise<void> {
@@ -428,55 +417,47 @@ export default class FormatterTool implements ToolInterface {
     this.client = undefined;
   }
 
-  async restart(
-    outputChannel: LogOutputChannel,
-    configService: ConfigService,
-    statusBarItemHandler: StatusBarItemHandler,
-  ): Promise<void> {
+  async restart(): Promise<void> {
     await this.deactivate();
-    const newBinaryPath = await this.getBinary(outputChannel, configService);
-    await this.activate(outputChannel, configService, statusBarItemHandler, newBinaryPath);
+    const newBinaryPath = await this.getBinary();
+    await this.activate(newBinaryPath);
   }
 
-  async toggleClient(configService: ConfigService): Promise<void> {
+  async toggleClient(): Promise<void> {
     if (this.client === undefined) {
       return;
     }
 
     if (this.client.isRunning()) {
-      if (!configService.vsCodeConfig.enableOxfmt) {
+      if (!this.configService.vsCodeConfig.enableOxfmt) {
         await this.client.stop();
       }
     } else {
-      if (configService.vsCodeConfig.enableOxfmt) {
+      if (this.configService.vsCodeConfig.enableOxfmt) {
         await this.client.start();
       }
     }
   }
 
-  async onConfigChange(
-    event: ConfigurationChangeEvent,
-    configService: ConfigService,
-    statusBarItemHandler: StatusBarItemHandler,
-  ): Promise<void> {
+  async onConfigChange(event: ConfigurationChangeEvent): Promise<void> {
     if (
       event.affectsConfiguration(`${ConfigService.namespace}.enable`) ||
       event.affectsConfiguration(`${ConfigService.namespace}.enable.oxfmt`)
     ) {
-      await this.toggleClient(configService); // update the client state
+      await this.toggleClient(); // update the client state
     }
-    this.updateStatusBar(statusBarItemHandler, configService);
+    this.updateStatusBar();
 
     if (this.client === undefined) {
       return;
     }
 
     // update the initializationOptions for a possible restart
-    this.client.clientOptions.initializationOptions = configService.formatterServerConfig;
+    this.client.clientOptions.initializationOptions = this.configService.formatterServerConfig;
 
-    if (configService.effectsWorkspaceConfigChange(event) && this.client.isRunning()) {
+    if (this.configService.effectsWorkspaceConfigChange(event) && this.client.isRunning()) {
       await this.client.sendNotification("workspace/didChangeConfiguration", {
-        settings: configService.formatterServerConfig,
+        settings: this.configService.formatterServerConfig,
       });
     }
   }
@@ -487,11 +468,8 @@ export default class FormatterTool implements ToolInterface {
     this.formatActionProvider.dispose();
   }
 
-  private updateStatusBar(
-    statusBarItemHandler: StatusBarItemHandler,
-    configService: ConfigService,
-  ) {
-    const enable = configService.vsCodeConfig.enableOxfmt;
+  private updateStatusBar() {
+    const enable = this.configService.vsCodeConfig.enableOxfmt;
 
     let text =
       `[$(terminal) Open Output](command:${OxcCommands.ShowOutputChannelFmt})\n\n` +
@@ -508,7 +486,7 @@ export default class FormatterTool implements ToolInterface {
       text = `${tooltipText}\n\n` + text;
     }
 
-    statusBarItemHandler.updateTool(
+    this.statusBarItemHandler.updateTool(
       "formatter",
       enable,
       text,

--- a/client/tools/formatter.ts
+++ b/client/tools/formatter.ts
@@ -12,7 +12,6 @@ import {
 } from "vscode";
 
 import {
-  DocumentFilter,
   ConfigurationParams,
   ShowMessageNotification,
 } from "vscode-languageclient";
@@ -252,7 +251,7 @@ export default class FormatterTool implements ToolInterface {
   // LSP client instance
   private client: LanguageClient | undefined;
 
-  private documentSelectors: DocumentFilter[] = [
+  private documentSelectors = [
     {
       pattern: `**/*.{${supportedExtensions.join(",")}}`,
       scheme: "file",
@@ -267,6 +266,50 @@ export default class FormatterTool implements ToolInterface {
   ];
 
   private disposeResources: (() => Promise<void>) | undefined;
+
+  // Dependencies needed by commands
+  private outputChannel: LogOutputChannel | undefined;
+  private configService: ConfigService | undefined;
+  private statusBarItemHandler: StatusBarItemHandler | undefined;
+
+  // Command and provider disposables (registered once at construction)
+  private readonly restartCommand: { dispose: () => void };
+  private readonly toggleEnableCommand: { dispose: () => void };
+  private readonly formatActionProvider: { dispose: () => void };
+
+  constructor() {
+    // Register commands once at construction
+    this.restartCommand = commands.registerCommand(OxcCommands.RestartServerFmt, async () => {
+      if (this.outputChannel && this.configService && this.statusBarItemHandler) {
+        await this.restart(this.outputChannel, this.configService, this.statusBarItemHandler);
+      }
+    });
+
+    this.toggleEnableCommand = commands.registerCommand(OxcCommands.ToggleEnableFmt, async () => {
+      if (this.configService) {
+        await this.configService.vsCodeConfig.updateEnableOxfmt(!this.configService.vsCodeConfig.enableOxfmt);
+      }
+    });
+
+    // Register code action provider once at construction
+    this.formatActionProvider = languages.registerCodeActionsProvider(
+      this.documentSelectors,
+      {
+        provideCodeActions: (doc) => {
+          if (
+            this.configService?.vsCodeConfig.enableOxfmt === false ||
+            workspace.getConfiguration("editor", doc).get("defaultFormatter") !== "oxc.oxc-vscode"
+          ) {
+            return [];
+          }
+          return [formatCodeAction];
+        },
+      },
+      {
+        providedCodeActionKinds: [formatCodeActionKind],
+      },
+    );
+  }
 
   getLspVersion(): string | undefined {
     return this.client?.initializeResult?.serverInfo?.version;
@@ -296,39 +339,17 @@ export default class FormatterTool implements ToolInterface {
     statusBarItemHandler: StatusBarItemHandler,
     binary?: BinarySearchResult,
   ) {
+    // Store dependencies for command handlers
+    this.outputChannel = outputChannel;
+    this.configService = configService;
+    this.statusBarItemHandler = statusBarItemHandler;
+
     // No valid binary found for the formatter.
     if (!binary) {
       statusBarItemHandler.updateTool("formatter", false, "No valid oxfmt binary found.");
       outputChannel.appendLine("No valid oxfmt binary found. Formatter will not be activated.");
       return Promise.resolve();
     }
-
-    const restartCommand = commands.registerCommand(OxcCommands.RestartServerFmt, async () => {
-      await this.restart(outputChannel, configService, statusBarItemHandler);
-    });
-
-    const toggleEnable = commands.registerCommand(OxcCommands.ToggleEnableFmt, async () => {
-      await configService.vsCodeConfig.updateEnableOxfmt(!configService.vsCodeConfig.enableOxfmt);
-    });
-
-    const formatAction = languages.registerCodeActionsProvider(
-      // @ts-expect-error DocumentFilter/DocumentSelector is not correctly typed, here it expects a readonly array, which we provide.
-      this.documentSelectors,
-      {
-        provideCodeActions: (doc) => {
-          if (
-            configService.vsCodeConfig.enableOxfmt === false ||
-            workspace.getConfiguration("editor", doc).get("defaultFormatter") !== "oxc.oxc-vscode"
-          ) {
-            return [];
-          }
-          return [formatCodeAction];
-        },
-      },
-      {
-        providedCodeActionKinds: [formatCodeActionKind],
-      },
-    );
 
     outputChannel.info(`Using server binary at: ${binary?.path}`);
 
@@ -384,9 +405,6 @@ export default class FormatterTool implements ToolInterface {
 
     this.disposeResources = async () => {
       await this.client?.dispose();
-      restartCommand.dispose();
-      toggleEnable.dispose();
-      formatAction.dispose();
       onNotificationDispose.dispose();
     };
 
@@ -459,6 +477,12 @@ export default class FormatterTool implements ToolInterface {
         settings: configService.formatterServerConfig,
       });
     }
+  }
+
+  dispose(): void {
+    this.restartCommand.dispose();
+    this.toggleEnableCommand.dispose();
+    this.formatActionProvider.dispose();
   }
 
   private updateStatusBar(

--- a/client/tools/formatter.ts
+++ b/client/tools/formatter.ts
@@ -11,10 +11,7 @@ import {
   workspace,
 } from "vscode";
 
-import {
-  ConfigurationParams,
-  ShowMessageNotification,
-} from "vscode-languageclient";
+import { ConfigurationParams, ShowMessageNotification } from "vscode-languageclient";
 
 import {
   Executable,
@@ -287,7 +284,9 @@ export default class FormatterTool implements ToolInterface {
 
     this.toggleEnableCommand = commands.registerCommand(OxcCommands.ToggleEnableFmt, async () => {
       if (this.configService) {
-        await this.configService.vsCodeConfig.updateEnableOxfmt(!this.configService.vsCodeConfig.enableOxfmt);
+        await this.configService.vsCodeConfig.updateEnableOxfmt(
+          !this.configService.vsCodeConfig.enableOxfmt,
+        );
       }
     });
 

--- a/client/tools/linter.ts
+++ b/client/tools/linter.ts
@@ -48,21 +48,20 @@ export default class LinterTool implements ToolInterface {
 
   private disposeResources: (() => Promise<void>) | undefined;
 
-  // Dependencies needed by commands
-  private outputChannel: LogOutputChannel | undefined;
-  private configService: ConfigService | undefined;
-  private statusBarItemHandler: StatusBarItemHandler | undefined;
-
   // Command disposables (registered once at construction)
   private readonly restartCommand: { dispose: () => void };
   private readonly toggleEnableCommand: { dispose: () => void };
   private readonly applyAllFixesCommand: { dispose: () => void };
 
-  constructor() {
+  constructor(
+    private readonly outputChannel: LogOutputChannel,
+    private readonly configService: ConfigService,
+    private readonly statusBarItemHandler: StatusBarItemHandler,
+  ) {
     // Register commands once at construction
     this.restartCommand = commands.registerCommand(OxcCommands.RestartServerLint, async () => {
       if (this.outputChannel && this.configService && this.statusBarItemHandler) {
-        await this.restart(this.outputChannel, this.configService, this.statusBarItemHandler);
+        await this.restart();
       }
     });
 
@@ -106,59 +105,46 @@ export default class LinterTool implements ToolInterface {
     return this.client?.initializeResult?.serverInfo?.version;
   }
 
-  async getBinary(
-    outputChannel: LogOutputChannel,
-    configService: ConfigService,
-  ): Promise<BinarySearchResult | undefined> {
+  async getBinary(): Promise<BinarySearchResult | undefined> {
     if (process.env.SERVER_PATH_DEV) {
       return { path: process.env.SERVER_PATH_DEV, loader: "native" };
     }
-    const bin = await configService.getOxlintServerBinPath();
+    const bin = await this.configService.getOxlintServerBinPath();
     if (bin) {
       try {
         await fsPromises.access(bin.path);
         return bin;
       } catch (e) {
-        outputChannel.error(`Invalid bin path: ${bin.path}`, e);
+        this.outputChannel.error(`Invalid bin path: ${bin.path}`, e);
       }
     }
   }
 
-  async activate(
-    outputChannel: LogOutputChannel,
-    configService: ConfigService,
-    statusBarItemHandler: StatusBarItemHandler,
-    binary?: BinarySearchResult,
-  ): Promise<void> {
-    // Store dependencies for command handlers
-    this.outputChannel = outputChannel;
-    this.configService = configService;
-    this.statusBarItemHandler = statusBarItemHandler;
-
+  async activate(binary?: BinarySearchResult): Promise<void> {
     if (!binary) {
-      statusBarItemHandler.updateTool("linter", false, "No valid oxlint binary found.");
-      outputChannel.appendLine("No valid oxlint binary found. Linter will not be activated.");
+      this.statusBarItemHandler.updateTool("linter", false, "No valid oxlint binary found.");
+      this.outputChannel.appendLine("No valid oxlint binary found. Linter will not be activated.");
       return Promise.resolve();
     }
 
-    this.allowedToStartServer = configService.vsCodeConfig.requireConfig
+    this.allowedToStartServer = this.configService.vsCodeConfig.requireConfig
       ? (await workspace.findFiles(oxlintConfigDefaultFilePattern, "**/node_modules/**", 1))
           .length > 0
       : true;
 
     const run: Executable = await runExecutable(
       binary,
-      configService.vsCodeConfig.useExecPath,
-      configService.vsCodeConfig.nodePath,
-      configService.vsCodeConfig.binPathTsGoLint,
-      configService.vsCodeConfig.suppressProgramErrors,
+      this.configService.vsCodeConfig.useExecPath,
+      this.configService.vsCodeConfig.nodePath,
+      this.configService.vsCodeConfig.binPathTsGoLint,
+      this.configService.vsCodeConfig.suppressProgramErrors,
     );
     const serverOptions: ServerOptions = {
       run,
       debug: run,
     };
 
-    outputChannel.info(`Using server binary at: ${binary?.path}`);
+    this.outputChannel.info(`Using server binary at: ${binary?.path}`);
 
     // see https://github.com/oxc-project/oxc/blob/9b475ad05b750f99762d63094174be6f6fc3c0eb/crates/oxc_linter/src/loader/partial_loader/mod.rs#L17-L20
     const supportedExtensions = [
@@ -186,14 +172,15 @@ export default class LinterTool implements ToolInterface {
           scheme: "file",
         },
       ],
-      initializationOptions: configService.oxlintServerConfig,
-      outputChannel,
-      traceOutputChannel: outputChannel,
+      initializationOptions: this.configService.oxlintServerConfig,
+      outputChannel: this.outputChannel,
+      traceOutputChannel: this.outputChannel,
       diagnosticPullOptions: {
         onChange: true,
         onSave: true,
         onTabs: false,
-        filter: (document, mode) => !configService.shouldRequestDiagnostics(document.uri, mode),
+        filter: (document, mode) =>
+          !this.configService.shouldRequestDiagnostics(document.uri, mode),
       },
       middleware: {
         handleDiagnostics: (uri, diagnostics, next) => {
@@ -223,7 +210,8 @@ export default class LinterTool implements ToolInterface {
               }
 
               return (
-                configService.getWorkspaceConfig(Uri.parse(item.scopeUri))?.toOxlintConfig() ?? null
+                this.configService.getWorkspaceConfig(Uri.parse(item.scopeUri))?.toOxlintConfig() ??
+                null
               );
             });
           },
@@ -236,7 +224,7 @@ export default class LinterTool implements ToolInterface {
     const onNotificationDispose = this.client.onNotification(
       ShowMessageNotification.type,
       (params) => {
-        onClientNotification(params, outputChannel);
+        onClientNotification(params, this.outputChannel);
       },
     );
 
@@ -248,14 +236,11 @@ export default class LinterTool implements ToolInterface {
 
     let activatorDispatcher: { dispose: () => void } | undefined;
     if (this.allowedToStartServer) {
-      if (configService.vsCodeConfig.enableOxlint) {
+      if (this.configService.vsCodeConfig.enableOxlint) {
         await this.client.start();
       }
     } else {
-      activatorDispatcher = this.generateActivatorByConfig(
-        configService.vsCodeConfig,
-        statusBarItemHandler,
-      );
+      activatorDispatcher = this.generateActivatorByConfig(this.configService.vsCodeConfig);
     }
 
     this.disposeResources = async () => {
@@ -265,7 +250,7 @@ export default class LinterTool implements ToolInterface {
       activatorDispatcher?.dispose();
     };
 
-    this.updateStatusBar(statusBarItemHandler, configService.vsCodeConfig.enableOxlint);
+    this.updateStatusBar(this.configService.vsCodeConfig.enableOxlint);
   }
 
   async deactivate(): Promise<void> {
@@ -301,39 +286,31 @@ export default class LinterTool implements ToolInterface {
     }
   }
 
-  async restart(
-    outputChannel: LogOutputChannel,
-    configService: ConfigService,
-    statusBarItemHandler: StatusBarItemHandler,
-  ): Promise<void> {
+  async restart(): Promise<void> {
     await this.deactivate();
-    const newBinaryPath = await this.getBinary(outputChannel, configService);
-    await this.activate(outputChannel, configService, statusBarItemHandler, newBinaryPath);
+    const newBinaryPath = await this.getBinary();
+    await this.activate(newBinaryPath);
   }
 
-  async onConfigChange(
-    event: ConfigurationChangeEvent,
-    configService: ConfigService,
-    statusBarItemHandler: StatusBarItemHandler,
-  ): Promise<void> {
+  async onConfigChange(event: ConfigurationChangeEvent): Promise<void> {
     if (
       event.affectsConfiguration(`${ConfigService.namespace}.enable`) ||
       event.affectsConfiguration(`${ConfigService.namespace}.enable.oxlint`)
     ) {
-      await this.toggleClient(configService); // update the client state
+      await this.toggleClient(this.configService); // update the client state
     }
-    this.updateStatusBar(statusBarItemHandler, configService.vsCodeConfig.enableOxlint);
+    this.updateStatusBar(this.configService.vsCodeConfig.enableOxlint);
 
     if (this.client === undefined) {
       return;
     }
 
     // update the initializationOptions for a possible restart
-    this.client.clientOptions.initializationOptions = configService.oxlintServerConfig;
+    this.client.clientOptions.initializationOptions = this.configService.oxlintServerConfig;
 
-    if (configService.effectsWorkspaceConfigChange(event) && this.client.isRunning()) {
+    if (this.configService.effectsWorkspaceConfigChange(event) && this.client.isRunning()) {
       await this.client.sendNotification("workspace/didChangeConfiguration", {
-        settings: configService.oxlintServerConfig,
+        settings: this.configService.oxlintServerConfig,
       });
     }
   }
@@ -366,7 +343,7 @@ export default class LinterTool implements ToolInterface {
     };
   }
 
-  updateStatusBar(statusBarItemHandler: StatusBarItemHandler, enable: boolean) {
+  updateStatusBar(enable: boolean) {
     const { isEnabled, tooltipText } = this.getStatusBarState(enable);
 
     let text =
@@ -383,7 +360,7 @@ export default class LinterTool implements ToolInterface {
       text = `${tooltipText}\n\n` + text;
     }
 
-    statusBarItemHandler.updateTool(
+    this.statusBarItemHandler.updateTool(
       "linter",
       isEnabled,
       text,
@@ -391,10 +368,7 @@ export default class LinterTool implements ToolInterface {
     );
   }
 
-  generateActivatorByConfig(
-    config: VSCodeConfig,
-    statusBarItemHandler: StatusBarItemHandler,
-  ): { dispose: () => void } {
+  generateActivatorByConfig(config: VSCodeConfig): { dispose: () => void } {
     const watcher = workspace.createFileSystemWatcher(
       oxlintConfigDefaultFilePattern,
       false,
@@ -403,7 +377,7 @@ export default class LinterTool implements ToolInterface {
     );
     watcher.onDidCreate(async () => {
       this.allowedToStartServer = true;
-      this.updateStatusBar(statusBarItemHandler, config.enableOxlint);
+      this.updateStatusBar(config.enableOxlint);
       if (this.client && !this.client.isRunning() && config.enableOxlint) {
         await this.client.start();
       }
@@ -415,7 +389,7 @@ export default class LinterTool implements ToolInterface {
         (await workspace.findFiles(oxlintConfigDefaultFilePattern, "**/node_modules/**", 1))
           .length > 0;
       if (!this.allowedToStartServer) {
-        this.updateStatusBar(statusBarItemHandler, false);
+        this.updateStatusBar(false);
         if (this.client && this.client.isRunning()) {
           await this.client.stop();
         }

--- a/client/tools/linter.ts
+++ b/client/tools/linter.ts
@@ -48,6 +48,55 @@ export default class LinterTool implements ToolInterface {
 
   private disposeResources: (() => Promise<void>) | undefined;
 
+  // Dependencies needed by commands
+  private outputChannel: LogOutputChannel | undefined;
+  private configService: ConfigService | undefined;
+  private statusBarItemHandler: StatusBarItemHandler | undefined;
+
+  // Command disposables (registered once at construction)
+  private readonly restartCommand: { dispose: () => void };
+  private readonly toggleEnableCommand: { dispose: () => void };
+  private readonly applyAllFixesCommand: { dispose: () => void };
+
+  constructor() {
+    // Register commands once at construction
+    this.restartCommand = commands.registerCommand(OxcCommands.RestartServerLint, async () => {
+      if (this.outputChannel && this.configService && this.statusBarItemHandler) {
+        await this.restart(this.outputChannel, this.configService, this.statusBarItemHandler);
+      }
+    });
+
+    this.toggleEnableCommand = commands.registerCommand(OxcCommands.ToggleEnableLint, async () => {
+      if (this.configService) {
+        await this.configService.vsCodeConfig.updateEnableOxlint(!this.configService.vsCodeConfig.enableOxlint);
+        // all future changes are handled by the onConfigChange listener, so we don't need to do it here
+      }
+    });
+
+    this.applyAllFixesCommand = commands.registerCommand(OxcCommands.ApplyAllFixesFile, async () => {
+      if (!this.client) {
+        window.showErrorMessage("oxc client not found");
+        return;
+      }
+      const textEditor = window.activeTextEditor;
+      if (!textEditor) {
+        window.showErrorMessage("active text editor not found");
+        return;
+      }
+
+      const params = {
+        command: LspCommands.FixAll,
+        arguments: [
+          {
+            uri: textEditor.document.uri.toString(),
+          },
+        ],
+      };
+
+      await this.client.sendRequest(ExecuteCommandRequest.type, params);
+    });
+  }
+
   getLspVersion(): string | undefined {
     return this.client?.initializeResult?.serverInfo?.version;
   }
@@ -76,6 +125,11 @@ export default class LinterTool implements ToolInterface {
     statusBarItemHandler: StatusBarItemHandler,
     binary?: BinarySearchResult,
   ): Promise<void> {
+    // Store dependencies for command handlers
+    this.outputChannel = outputChannel;
+    this.configService = configService;
+    this.statusBarItemHandler = statusBarItemHandler;
+
     if (!binary) {
       statusBarItemHandler.updateTool("linter", false, "No valid oxlint binary found.");
       outputChannel.appendLine("No valid oxlint binary found. Linter will not be activated.");
@@ -84,40 +138,8 @@ export default class LinterTool implements ToolInterface {
 
     this.allowedToStartServer = configService.vsCodeConfig.requireConfig
       ? (await workspace.findFiles(oxlintConfigDefaultFilePattern, "**/node_modules/**", 1))
-          .length > 0
+        .length > 0
       : true;
-
-    const restartCommand = commands.registerCommand(OxcCommands.RestartServerLint, async () => {
-      await this.restart(outputChannel, configService, statusBarItemHandler);
-    });
-
-    const toggleEnable = commands.registerCommand(OxcCommands.ToggleEnableLint, async () => {
-      await configService.vsCodeConfig.updateEnableOxlint(!configService.vsCodeConfig.enableOxlint);
-      // all future changes are handled by the onConfigChange listener, so we don't need to do it here
-    });
-
-    const applyAllFixesFile = commands.registerCommand(OxcCommands.ApplyAllFixesFile, async () => {
-      if (!this.client) {
-        window.showErrorMessage("oxc client not found");
-        return;
-      }
-      const textEditor = window.activeTextEditor;
-      if (!textEditor) {
-        window.showErrorMessage("active text editor not found");
-        return;
-      }
-
-      const params = {
-        command: LspCommands.FixAll,
-        arguments: [
-          {
-            uri: textEditor.document.uri.toString(),
-          },
-        ],
-      };
-
-      await this.client.sendRequest(ExecuteCommandRequest.type, params);
-    });
 
     const run: Executable = await runExecutable(
       binary,
@@ -233,9 +255,6 @@ export default class LinterTool implements ToolInterface {
 
     this.disposeResources = async () => {
       await this.client?.dispose();
-      restartCommand.dispose();
-      toggleEnable.dispose();
-      applyAllFixesFile.dispose();
       onNotificationDispose.dispose();
       onDeleteFilesDispose.dispose();
       activatorDispatcher?.dispose();
@@ -253,6 +272,12 @@ export default class LinterTool implements ToolInterface {
     await this.disposeResources?.();
     this.disposeResources = undefined;
     this.client = undefined;
+  }
+
+  dispose(): void {
+    this.restartCommand.dispose();
+    this.toggleEnableCommand.dispose();
+    this.applyAllFixesCommand.dispose();
   }
 
   async toggleClient(configService: ConfigService): Promise<void> {

--- a/client/tools/linter.ts
+++ b/client/tools/linter.ts
@@ -68,33 +68,38 @@ export default class LinterTool implements ToolInterface {
 
     this.toggleEnableCommand = commands.registerCommand(OxcCommands.ToggleEnableLint, async () => {
       if (this.configService) {
-        await this.configService.vsCodeConfig.updateEnableOxlint(!this.configService.vsCodeConfig.enableOxlint);
+        await this.configService.vsCodeConfig.updateEnableOxlint(
+          !this.configService.vsCodeConfig.enableOxlint,
+        );
         // all future changes are handled by the onConfigChange listener, so we don't need to do it here
       }
     });
 
-    this.applyAllFixesCommand = commands.registerCommand(OxcCommands.ApplyAllFixesFile, async () => {
-      if (!this.client) {
-        window.showErrorMessage("oxc client not found");
-        return;
-      }
-      const textEditor = window.activeTextEditor;
-      if (!textEditor) {
-        window.showErrorMessage("active text editor not found");
-        return;
-      }
+    this.applyAllFixesCommand = commands.registerCommand(
+      OxcCommands.ApplyAllFixesFile,
+      async () => {
+        if (!this.client) {
+          window.showErrorMessage("oxc client not found");
+          return;
+        }
+        const textEditor = window.activeTextEditor;
+        if (!textEditor) {
+          window.showErrorMessage("active text editor not found");
+          return;
+        }
 
-      const params = {
-        command: LspCommands.FixAll,
-        arguments: [
-          {
-            uri: textEditor.document.uri.toString(),
-          },
-        ],
-      };
+        const params = {
+          command: LspCommands.FixAll,
+          arguments: [
+            {
+              uri: textEditor.document.uri.toString(),
+            },
+          ],
+        };
 
-      await this.client.sendRequest(ExecuteCommandRequest.type, params);
-    });
+        await this.client.sendRequest(ExecuteCommandRequest.type, params);
+      },
+    );
   }
 
   getLspVersion(): string | undefined {
@@ -138,7 +143,7 @@ export default class LinterTool implements ToolInterface {
 
     this.allowedToStartServer = configService.vsCodeConfig.requireConfig
       ? (await workspace.findFiles(oxlintConfigDefaultFilePattern, "**/node_modules/**", 1))
-        .length > 0
+          .length > 0
       : true;
 
     const run: Executable = await runExecutable(

--- a/tests/integration/commands.spec.ts
+++ b/tests/integration/commands.spec.ts
@@ -26,7 +26,9 @@ teardown(async () => {
 
 suite("commands", () => {
   testSingleFolderMode("listed commands", async () => {
-    const oxcCommands = (await commands.getCommands(true)).filter((x) => x.startsWith("oxc.")).sort();
+    const oxcCommands = (await commands.getCommands(true))
+      .filter((x) => x.startsWith("oxc."))
+      .sort();
 
     const expectedCommands = [
       "oxc.showOutputChannel",

--- a/tests/integration/commands.spec.ts
+++ b/tests/integration/commands.spec.ts
@@ -26,7 +26,7 @@ teardown(async () => {
 
 suite("commands", () => {
   testSingleFolderMode("listed commands", async () => {
-    const oxcCommands = (await commands.getCommands(true)).filter((x) => x.startsWith("oxc."));
+    const oxcCommands = (await commands.getCommands(true)).filter((x) => x.startsWith("oxc.")).sort();
 
     const expectedCommands = [
       "oxc.showOutputChannel",
@@ -50,7 +50,7 @@ suite("commands", () => {
       expectedCommands.push("oxc.restartServerFormatter", "oxc.toggleEnableFormatter");
     }
 
-    deepStrictEqual(expectedCommands, oxcCommands);
+    deepStrictEqual(expectedCommands.sort(), oxcCommands);
   });
 
   testSingleFolderMode("oxc.showOutputChannel", async () => {

--- a/tests/integration/commands.spec.ts
+++ b/tests/integration/commands.spec.ts
@@ -26,8 +26,7 @@ teardown(async () => {
 
 suite("commands", () => {
   testSingleFolderMode("listed commands", async () => {
-    const oxcCommands = (await commands.getCommands(true))
-      .filter((x) => x.startsWith("oxc."));
+    const oxcCommands = (await commands.getCommands(true)).filter((x) => x.startsWith("oxc."));
 
     const expectedCommands = [
       "oxc.showOutputChannel",

--- a/tests/integration/commands.spec.ts
+++ b/tests/integration/commands.spec.ts
@@ -27,8 +27,7 @@ teardown(async () => {
 suite("commands", () => {
   testSingleFolderMode("listed commands", async () => {
     const oxcCommands = (await commands.getCommands(true))
-      .filter((x) => x.startsWith("oxc."))
-      .sort();
+      .filter((x) => x.startsWith("oxc."));
 
     const expectedCommands = [
       "oxc.showOutputChannel",
@@ -52,7 +51,7 @@ suite("commands", () => {
       expectedCommands.push("oxc.restartServerFormatter", "oxc.toggleEnableFormatter");
     }
 
-    deepStrictEqual(expectedCommands.sort(), oxcCommands);
+    deepStrictEqual(expectedCommands, oxcCommands);
   });
 
   testSingleFolderMode("oxc.showOutputChannel", async () => {


### PR DESCRIPTION
fixes an issue I had where not finding a binary meant the commands don't register ever, meaning the entire extension host had to be reloaded (most commonly via reloading a window which made it worse)

AI disclaimer: did end up using AI for this, my initial implementation simply moved the registration blocks of code to be higher than the if (!binary) check but this would cause problems when the reload command was ran because the commands were already registered. final implementation simply registers it once at class construction (for both LinterTool and FormatterTool)