### PR TITLE
chore: add VS Code debug launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "extensionHost",
+      "request": "launch",
+      "name": "Launch VS Code Extension",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "env": {
+        "RUST_LOG": "debug"
+      },
+      "preLaunchTask": "compile:dev"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "shell",
+      "label": "compile:dev",
+      "command": "DEV=true pnpm run compile",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "panel": "dedicated",
+        "reveal": "always"
+      }
+    }
+  ]
+}

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -8,7 +8,7 @@ const output: RolldownOptions["output"] = {
   sourcemap: true,
   format: "cjs",
   banner: `"use strict";\n`,
-  minify: true,
+  minify: process.env.DEV !== "true",
   cleanDir: true,
 };
 


### PR DESCRIPTION
This PR is a port of https://github.com/oxc-project/oxc/pull/16087.

The contributing page https://oxc.rs/docs/contribute/vscode.html mentions that there is a `Launch VS Code Extension` configuration. 

![](https://github.com/user-attachments/assets/f3ff06a0-15b6-4357-bd59-bf5619306439)

but the launch configuration was not included into this repository when we migrated in https://github.com/oxc-project/oxc/pull/18982.


https://github.com/user-attachments/assets/8f6a7e37-ff03-4ef9-832f-da098a7deef7

